### PR TITLE
20220203 fix opt bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "clvm_tools_rs"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bls12_381",
  "bytestream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm_tools_rs"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm_tools_rs"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/classic/clvm_tools/clvmc.rs
+++ b/src/classic/clvm_tools/clvmc.rs
@@ -134,7 +134,6 @@ pub fn compile_clvm(
                 Ok(output_path.to_string())
             }
         } else {
-            log::info(format!("skipping {}, compiled recently", input_path));
             Ok(output_path.to_string())
         }
     })

--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -874,7 +874,6 @@ fn hoist_body_let_binding(
 ) -> (Vec<HelperForm>, Rc<BodyForm>) {
     match body.borrow() {
         BodyForm::Let(l, LetFormKind::Parallel, bindings, body) => {
-            println!("hoist_body_let_binding for {} with context {}", body.to_sexp().to_string(), outer_context.as_ref().map(|x| x.to_string()).unwrap_or_else(|| "None".to_string()));
             let defun_name = gensym("letbinding".as_bytes().to_vec());
             let generated_defun = generate_let_defun(
                 compiler,
@@ -909,8 +908,6 @@ fn hoist_body_let_binding(
             call_args.append(&mut let_args);
 
             let final_call = BodyForm::Call(l.clone(), call_args);
-            println!("generating call {}", final_call.to_sexp().to_string());
-            println!("to {}", generated_defun.to_sexp().to_string());
             (vec![generated_defun], Rc::new(final_call.clone()))
         }
         _ => (Vec::new(), body.clone()),

--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -55,11 +55,14 @@ use crate::util::{number_from_u8, u8_from_number};
 fn cons_bodyform(loc: Srcloc, left: Rc<BodyForm>, right: Rc<BodyForm>) -> BodyForm {
     BodyForm::Call(
         loc.clone(),
-        vec!(
-            Rc::new(BodyForm::Value(SExp::Atom(loc.clone(), "c".as_bytes().to_vec()))), // Cons
+        vec![
+            Rc::new(BodyForm::Value(SExp::Atom(
+                loc.clone(),
+                "c".as_bytes().to_vec(),
+            ))), // Cons
             left.clone(),
-            right.clone()
-        )
+            right.clone(),
+        ],
     )
 }
 
@@ -69,13 +72,11 @@ fn cons_bodyform(loc: Srcloc, left: Rc<BodyForm>, right: Rc<BodyForm>) -> BodyFo
  */
 fn create_let_env_expression(args: Rc<SExp>) -> BodyForm {
     match args.borrow() {
-        SExp::Cons(l, a, b) => {
-            cons_bodyform(
-                l.clone(),
-                Rc::new(create_let_env_expression(a.clone())),
-                Rc::new(create_let_env_expression(b.clone()))
-            )
-        },
+        SExp::Cons(l, a, b) => cons_bodyform(
+            l.clone(),
+            Rc::new(create_let_env_expression(a.clone())),
+            Rc::new(create_let_env_expression(b.clone())),
+        ),
         _ => {
             let cloned: &SExp = args.borrow();
             BodyForm::Value(cloned.clone())
@@ -873,10 +874,9 @@ fn hoist_body_let_binding(
                 body.clone(),
             );
             let mut let_args = generate_let_args(l.clone(), bindings.to_vec());
-            let pass_env =
-                outer_context.
-                map(|x| create_let_env_expression(x)).
-                unwrap_or_else(|| {
+            let pass_env = outer_context
+                .map(|x| create_let_env_expression(x))
+                .unwrap_or_else(|| {
                     BodyForm::Call(
                         l.clone(),
                         vec![
@@ -916,7 +916,8 @@ fn process_helper_let_bindings(
         match result[i].clone() {
             HelperForm::Defun(l, name, inline, args, body) => {
                 let context = if (inline) { Some(args.clone()) } else { None };
-                let helper_result = hoist_body_let_binding(compiler, context, args.clone(), body.clone());
+                let helper_result =
+                    hoist_body_let_binding(compiler, context, args.clone(), body.clone());
                 let hoisted_helpers = helper_result.0;
                 let hoisted_body = helper_result.1.clone();
 

--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -15,7 +15,7 @@ use crate::compiler::compiler::run_optimizer;
 use crate::compiler::comptypes::{
     cons_of_string_map, foldM, join_vecs_to_string, list_to_cons, mapM, with_heading, Binding,
     BodyForm, Callable, CompileErr, CompileForm, CompiledCode, CompilerOpts, DefunCall, HelperForm,
-    InlineFunction, PrimaryCodegen, LetFormKind
+    InlineFunction, LetFormKind, PrimaryCodegen,
 };
 use crate::compiler::debug::{build_swap_table_mut, relabel};
 use crate::compiler::frontend::compile_bodyform;
@@ -346,9 +346,12 @@ pub fn process_macro_call(
     let args_to_macro = list_to_cons(l.clone(), &converted_args);
     build_swap_table_mut(&mut swap_table, &args_to_macro);
 
-    let arg_strs: Vec<String> =
-        args.iter().map(|x| x.to_sexp().to_string()).collect();
-    println!("process macro args {:?} code {}", arg_strs, code.to_string());
+    let arg_strs: Vec<String> = args.iter().map(|x| x.to_sexp().to_string()).collect();
+    println!(
+        "process macro args {:?} code {}",
+        arg_strs,
+        code.to_string()
+    );
 
     run(
         allocator,
@@ -488,17 +491,15 @@ fn compile_call(
                 Rc::new(code),
             ),
 
-            Callable::CallInline(l, inline) => {
-                replace_in_inline(
-                    allocator,
-                    runner.clone(),
-                    opts.clone(),
-                    compiler,
-                    l.clone(),
-                    &inline,
-                    &tl,
-                )
-            },
+            Callable::CallInline(l, inline) => replace_in_inline(
+                allocator,
+                runner.clone(),
+                opts.clone(),
+                compiler,
+                l.clone(),
+                &inline,
+                &tl,
+            ),
 
             Callable::CallDefun(l, lookup) => {
                 generate_args_code(allocator, runner, opts.clone(), compiler, l.clone(), &tl)
@@ -923,7 +924,8 @@ fn process_helper_let_bindings(
         match result[i].clone() {
             HelperForm::Defun(l, name, inline, args, body) => {
                 let context = if (inline) { Some(args.clone()) } else { None };
-                let helper_result = hoist_body_let_binding(compiler, context, args.clone(), body.clone());
+                let helper_result =
+                    hoist_body_let_binding(compiler, context, args.clone(), body.clone());
                 let hoisted_helpers = helper_result.0;
                 let hoisted_body = helper_result.1.clone();
 
@@ -1028,8 +1030,9 @@ fn finalize_env_(
                             c,
                             l.clone(),
                             res,
-                            &synthesize_args(res.args.clone())
-                        ).map(|x| x.1.clone()),
+                            &synthesize_args(res.args.clone()),
+                        )
+                        .map(|x| x.1.clone()),
                         None => {
                             /* Parentfns are functions in progress in the parent */
                             if !c.parentfns.get(v).is_none() {
@@ -1069,7 +1072,7 @@ fn finalize_env_(
             .map(|r| Rc::new(SExp::Cons(l.clone(), h.clone(), r.clone())))
         }),
 
-        _ => Ok(env.clone())
+        _ => Ok(env.clone()),
     }
 }
 
@@ -1088,7 +1091,7 @@ fn finalize_env(
             l.clone(),
             h.clone(),
         ),
-        _ => Ok(c.env.clone())
+        _ => Ok(c.env.clone()),
     }
 }
 

--- a/src/compiler/comptypes.rs
+++ b/src/compiler/comptypes.rs
@@ -28,7 +28,7 @@ impl InlineFunction {
         Rc::new(SExp::Cons(
             self.body.loc(),
             self.args.clone(),
-            self.body.to_sexp()
+            self.body.to_sexp(),
         ))
     }
 }
@@ -66,7 +66,7 @@ pub struct Binding {
 #[derive(Clone, Debug)]
 pub enum LetFormKind {
     Parallel,
-    Sequential
+    Sequential,
 }
 
 #[derive(Clone, Debug)]
@@ -271,11 +271,10 @@ impl BodyForm {
                     bindings.iter().map(|x| x.to_sexp()).collect();
                 let bindings_cons = list_to_cons(loc.clone(), &translated_bindings);
                 let translated_body = body.to_sexp();
-                let marker =
-                    match kind {
-                        LetFormKind::Parallel => "let",
-                        LetFormKind::Sequential => "let*"
-                    };
+                let marker = match kind {
+                    LetFormKind::Parallel => "let",
+                    LetFormKind::Sequential => "let*",
+                };
                 Rc::new(SExp::Cons(
                     loc.clone(),
                     Rc::new(SExp::atom_from_string(loc.clone(), &marker.to_string())),

--- a/src/compiler/frontend.rs
+++ b/src/compiler/frontend.rs
@@ -6,7 +6,8 @@ use std::rc::Rc;
 use crate::classic::clvm::__type_compatibility__::bi_one;
 
 use crate::compiler::comptypes::{
-    list_to_cons, Binding, BodyForm, CompileErr, CompileForm, CompilerOpts, HelperForm, ModAccum, LetFormKind,
+    list_to_cons, Binding, BodyForm, CompileErr, CompileForm, CompilerOpts, HelperForm,
+    LetFormKind, ModAccum,
 };
 use crate::compiler::preprocessor::preprocess;
 use crate::compiler::rename::rename_children_compileform;
@@ -278,17 +279,18 @@ pub fn compile_bodyform(body: Rc<SExp>) -> Result<BodyForm, CompileErr> {
 
                     match tail.proper_list() {
                         Some(v) => {
-                            if *atom_name == "let".as_bytes().to_vec() || *atom_name == "let*".as_bytes().to_vec() {
+                            if *atom_name == "let".as_bytes().to_vec()
+                                || *atom_name == "let*".as_bytes().to_vec()
+                            {
                                 if v.len() != 2 {
                                     return finish_err("let");
                                 }
 
-                                let kind =
-                                    if *atom_name == "let".as_bytes().to_vec() {
-                                        LetFormKind::Parallel
-                                    } else {
-                                        LetFormKind::Sequential
-                                    };
+                                let kind = if *atom_name == "let".as_bytes().to_vec() {
+                                    LetFormKind::Parallel
+                                } else {
+                                    LetFormKind::Sequential
+                                };
 
                                 let bindings = v[0].clone();
                                 let body = v[1].clone();

--- a/src/compiler/inline.rs
+++ b/src/compiler/inline.rs
@@ -180,6 +180,8 @@ fn replace_inline_body(
             // determine whether an inline is the next level.
             match get_inline_callable(opts.clone(), compiler, l.clone(), call_args[0].clone())? {
                 Callable::CallInline(_, new_inline) => {
+                    let pass_on_args: Vec<Rc<BodyForm>> =
+                        new_args.iter().skip(1).map(|x| x.clone()).collect();
                     replace_in_inline(
                         allocator,
                         runner,
@@ -187,7 +189,7 @@ fn replace_inline_body(
                         compiler,
                         l.clone(),
                         &new_inline,
-                        &new_args
+                        &pass_on_args
                     )
                 },
                 Callable::CallMacro(_, macro_body) => {

--- a/src/compiler/inline.rs
+++ b/src/compiler/inline.rs
@@ -94,12 +94,10 @@ fn pick_value_from_arg_element(match_args: Rc<SExp>, provided: Rc<BodyForm>, app
                 _ => None
             };
 
-            println!("pick_value_from_arg_element args {} provided {} name {} result {}", match_args.to_string(), provided.to_sexp().to_string(), SExp::Atom(l.clone(), name.clone()).to_string(), result.as_ref().map(|x| x.to_sexp().to_string()).unwrap_or_else(|| "None".to_string()));
             result
         },
         SExp::Atom(l, a) => {
             if *a == name {
-                println!("pick_value_from_arg_element args {} provided {} name {}", match_args.to_string(), apply(provided.clone()).to_sexp().to_string(), SExp::Atom(l.clone(), name.clone()).to_string());
                 Some(apply(provided))
             } else {
                 None
@@ -143,8 +141,6 @@ fn replace_inline_body(
     expr: Rc<BodyForm>,
 ) -> Result<Rc<BodyForm>, CompileErr> {
     let arg_str_vec: Vec<String> = args.iter().map(|x| x.to_sexp().to_string()).collect();
-
-    println!("replace_inline_body {} function {} expr {} args {:?}", SExp::Atom(loc.clone(), inline.name.to_vec()).to_string(), inline.to_sexp().to_string(), expr.to_sexp().to_string(), arg_str_vec);
 
     match expr.borrow() {
         BodyForm::Let(l, _, bindings, body) => Err(CompileErr(
@@ -217,7 +213,7 @@ pub fn replace_in_inline(
     args: &Vec<Rc<BodyForm>>,
 ) -> Result<Rc<BodyForm>, CompileErr> {
     let arg_str_vec: Vec<String> = args.iter().map(|x| x.to_sexp().to_string()).collect();
-    let res = replace_inline_body(
+    replace_inline_body(
         allocator,
         runner,
         opts,
@@ -226,7 +222,5 @@ pub fn replace_in_inline(
         inline,
         args,
         inline.body.clone(),
-    )?;
-    println!("replace_in_inline (defun-inline {} {} {}) with args {:?} gives {}", SExp::Atom(loc.clone(), inline.name.clone()).to_string(), inline.args.to_string(), inline.to_sexp().to_string(), arg_str_vec, res.to_sexp().to_string());
-    Ok(res)
+    )
 }

--- a/src/compiler/inline.rs
+++ b/src/compiler/inline.rs
@@ -82,10 +82,10 @@ fn pick_value_from_arg_element(match_args: Rc<SExp>, provided: Rc<BodyForm>, app
     match match_args.borrow() {
         SExp::Cons(l, a, b) => {
             let matched_a = pick_value_from_arg_element(a.clone(), provided.clone(), &|x| {
-                apply_fn(l.clone(), "f".to_string(), x.clone())
+                apply_fn(l.clone(), "f".to_string(), apply(x.clone()))
             }, name.clone());
             let matched_b = pick_value_from_arg_element(b.clone(), provided.clone(), &|x| {
-                apply_fn(l.clone(), "r".to_string(), x.clone())
+                apply_fn(l.clone(), "r".to_string(), apply(x.clone()))
             }, name.clone());
 
             let result = match (matched_a, matched_b) {

--- a/src/compiler/inline.rs
+++ b/src/compiler/inline.rs
@@ -8,34 +8,20 @@ use clvm_rs::allocator::Allocator;
 use crate::classic::clvm::__type_compatibility__::bi_one;
 use crate::classic::clvm_tools::stages::stage_0::TRunProgram;
 
-use crate::compiler::codegen::generate_expr_code;
+use crate::compiler::codegen::{
+    generate_expr_code,
+    get_callable,
+    get_call_name
+};
 use crate::compiler::comptypes::{
-    BodyForm, CompileErr, CompiledCode, CompilerOpts, InlineFunction, PrimaryCodegen,
+    BodyForm, CompileErr, CompiledCode, CompilerOpts, InlineFunction, PrimaryCodegen, Callable
 };
 use crate::compiler::sexp::{decode_string, SExp};
 use crate::compiler::srcloc::Srcloc;
 
 use crate::util::{u8_from_number, Number};
 
-#[derive(Clone)]
-struct InlineArgPath {
-    name: Vec<u8>,
-    path: Number,
-}
-
-#[derive(Clone)]
-enum InlineArgsSelect {
-    This(Vec<u8>),
-    Paths(Vec<InlineArgPath>),
-}
-
-#[derive(Clone)]
-enum InlineArgsType {
-    Whole(Vec<u8>),
-    List(Vec<InlineArgsSelect>),
-}
-
-fn at_form(loc: Srcloc, path: Number) -> Rc<BodyForm> {
+fn apply_fn(loc: Srcloc, name: String, expr: Rc<BodyForm>) -> Rc<BodyForm> {
     Rc::new(BodyForm::Call(
         loc.clone(),
         vec![
@@ -43,171 +29,20 @@ fn at_form(loc: Srcloc, path: Number) -> Rc<BodyForm> {
                 loc.clone(),
                 &"@".to_string(),
             ))),
-            Rc::new(BodyForm::Value(SExp::Integer(loc.clone(), path.clone()))),
+            expr
         ],
     ))
 }
 
-fn explore_arg_paths(arg: Rc<SExp>) -> Vec<InlineArgPath> {
-    match arg.borrow() {
-        SExp::Nil(_) => Vec::new(),
-        SExp::QuotedString(_, _, a) => Vec::new(),
-        SExp::Atom(_, a) => vec![InlineArgPath {
-            name: a.clone(),
-            path: bi_one(),
-        }],
-        SExp::Integer(_, i) => vec![InlineArgPath {
-            name: u8_from_number(i.clone()),
-            path: bi_one(),
-        }],
-        SExp::Cons(_, a, b) => {
-            let mut first_paths: Vec<InlineArgPath> = explore_arg_paths(a.clone())
-                .iter()
-                .map(|x| InlineArgPath {
-                    name: x.name.clone(),
-                    path: x.path.clone() * 2_i32.to_bigint().unwrap(),
-                })
-                .collect();
-            let mut rest_paths: Vec<InlineArgPath> = explore_arg_paths(b.clone())
-                .iter()
-                .map(|x| InlineArgPath {
-                    name: x.name.clone(),
-                    path: bi_one() + x.path.clone() * 2_i32.to_bigint().unwrap(),
-                })
-                .collect();
-            first_paths.append(&mut rest_paths);
-            first_paths
-        }
-    }
-}
-
-fn classify_inline_args(loc: Srcloc, args: Rc<SExp>) -> Result<InlineArgsType, CompileErr> {
-    let mut arg_look = args.clone();
-    let mut arg_list = Vec::new();
-
-    loop {
-        match arg_look.borrow() {
-            SExp::Nil(_) => {
-                return Ok(InlineArgsType::List(arg_list));
-            }
-            SExp::Cons(_, a, b) => match a.borrow() {
-                SExp::Nil(_) => {
-                    arg_list.push(InlineArgsSelect::This(Vec::new()));
-                    arg_look = b.clone();
-                }
-                SExp::Cons(l, _, _) => {
-                    let paths = explore_arg_paths(a.clone());
-                    arg_list.push(InlineArgsSelect::Paths(paths));
-                    arg_look = b.clone();
-                }
-                SExp::Atom(_, a) => {
-                    if a.len() == 0 {
-                        return Ok(InlineArgsType::List(arg_list));
-                    }
-
-                    arg_list.push(InlineArgsSelect::This(a.clone()));
-                    arg_look = b.clone();
-                }
-                _ => {
-                    break;
-                }
-            },
-            SExp::Atom(_, a) => {
-                return Ok(InlineArgsType::Whole(a.clone()));
-            }
-            _ => {
-                break;
-            }
-        }
-    }
-
-    return Err(CompileErr(
+fn at_form(loc: Srcloc, path: Number) -> Rc<BodyForm> {
+    apply_fn(
         loc.clone(),
-        format!(
-            "inappropriate arg form {} in args {}",
-            arg_look.to_string(),
-            args.to_string()
-        ),
-    ));
+        "@".to_string(),
+        Rc::new(BodyForm::Value(SExp::Integer(loc.clone(), path.clone())))
+    )
 }
 
-fn replace_in_inline_expr(
-    loc: Srcloc,
-    arg_lookup: &HashMap<Vec<u8>, Rc<BodyForm>>,
-    expr: Rc<BodyForm>,
-) -> Result<Rc<BodyForm>, CompileErr> {
-    match expr.borrow() {
-        BodyForm::Let(l, bindings, body) => Err(CompileErr(
-            loc.clone(),
-            "let binding should have been hoisted before optimization".to_string(),
-        )),
-        BodyForm::Quoted(v) => Ok(expr.clone()),
-        BodyForm::Call(l, args) => {
-            let mut new_args = Vec::new();
-            for i in 0..args.len() {
-                if i == 0 {
-                    new_args.push(args[i].clone());
-                } else {
-                    let replaced =
-                        replace_in_inline_expr(args[i].loc(), arg_lookup, args[i].clone())?;
-                    new_args.push(replaced);
-                }
-            }
-            Ok(Rc::new(BodyForm::Call(l.clone(), new_args)))
-        }
-        BodyForm::Value(SExp::Atom(_, a)) => arg_lookup
-            .get(a)
-            .map(|x| Ok(x.clone()))
-            .unwrap_or_else(|| Ok(expr.clone())),
-        BodyForm::Value(SExp::QuotedString(_, _, s)) => Ok(expr.clone()),
-        BodyForm::Value(SExp::Integer(_, i)) => {
-            let possible_name = u8_from_number(i.clone());
-            arg_lookup
-                .get(&possible_name)
-                .map(|x| Ok(x.clone()))
-                .unwrap_or_else(|| Ok(expr.clone()))
-        }
-        BodyForm::Value(v) => Ok(expr.clone()),
-    }
-}
-
-// Destructuring version.
-fn create_args_alist(
-    loc: Srcloc,
-    args: &Vec<InlineArgsSelect>,
-    arglist: &Vec<Rc<BodyForm>>,
-) -> HashMap<Vec<u8>, Rc<BodyForm>> {
-    let mut arg_lookup = HashMap::new();
-
-    for i in 0..args.len() {
-        match &args[i] {
-            InlineArgsSelect::This(n) => {
-                arg_lookup.insert(n.clone(), arglist[i].clone());
-            }
-            InlineArgsSelect::Paths(p) => {
-                for path in p.iter() {
-                    arg_lookup.insert(
-                        path.name.clone(),
-                        Rc::new(BodyForm::Call(
-                            loc.clone(),
-                            vec![
-                                Rc::new(BodyForm::Value(SExp::atom_from_string(
-                                    loc.clone(),
-                                    &"a".to_string(),
-                                ))),
-                                at_form(loc.clone(), path.path.clone()),
-                                arglist[i].clone(),
-                            ],
-                        )),
-                    );
-                }
-            }
-        }
-    }
-    arg_lookup
-}
-
-fn synthesize_args(arg_: Rc<SExp>) -> Vec<Rc<BodyForm>> {
+pub fn synthesize_args(arg_: Rc<SExp>) -> Vec<Rc<BodyForm>> {
     let mut start = 5_i32.to_bigint().unwrap();
     let mut result = Vec::new();
     let mut arg = arg_.clone();
@@ -225,61 +60,167 @@ fn synthesize_args(arg_: Rc<SExp>) -> Vec<Rc<BodyForm>> {
     }
 }
 
+fn enlist_remaining_args(loc: Srcloc, arg_choice: usize, args: &Vec<Rc<BodyForm>>) -> Rc<BodyForm> {
+    let mut result_body = BodyForm::Value(SExp::Nil(loc.clone()));
+
+    for i_reverse in arg_choice..args.len() {
+        let i = args.len() - i_reverse - 1;
+        result_body = BodyForm::Call(
+            loc.clone(),
+            vec!(
+                Rc::new(BodyForm::Value(SExp::atom_from_string(loc.clone(), &"c".to_string()))),
+                args[i].clone(),
+                Rc::new(result_body)
+            )
+        );
+    }
+
+    Rc::new(result_body)
+}
+
+fn pick_value_from_arg_element(match_args: Rc<SExp>, provided: Rc<BodyForm>, apply: &dyn Fn(Rc<BodyForm>) -> Rc<BodyForm>, name: Vec<u8>) -> Option<Rc<BodyForm>> {
+    match match_args.borrow() {
+        SExp::Cons(l, a, b) => {
+            let matched_a = pick_value_from_arg_element(a.clone(), provided.clone(), &|x| {
+                apply_fn(l.clone(), "f".to_string(), x.clone())
+            }, name.clone());
+            let matched_b = pick_value_from_arg_element(b.clone(), provided.clone(), &|x| {
+                apply_fn(l.clone(), "r".to_string(), x.clone())
+            }, name.clone());
+
+            match (matched_a, matched_b) {
+                (Some(a), _) => Some(a),
+                (_, Some(b)) => Some(b),
+                _ => None
+            }
+        },
+        SExp::Atom(_, a) => {
+            if *a == name {
+                Some(provided)
+            } else {
+                None
+            }
+        }
+        _ => None
+    }
+}
+
+fn arg_lookup(match_args: Rc<SExp>, arg_choice: usize, args: &Vec<Rc<BodyForm>>, name: Vec<u8>) -> Option<Rc<BodyForm>> {
+    match match_args.borrow() {
+        SExp::Cons(l, f, r) => {
+            match pick_value_from_arg_element(f.clone(), args[arg_choice].clone(), &|x| x.clone(), name.clone()) {
+                Some(x) => Some(x),
+                None => arg_lookup(r.clone(), arg_choice + 1, args, name.clone())
+            }
+        },
+        _ => pick_value_from_arg_element(match_args.clone(), enlist_remaining_args(match_args.loc(), arg_choice, args), &|x: Rc<BodyForm>| x.clone(), name)
+    }
+}
+
+fn get_inline_callable(
+    opts: Rc<dyn CompilerOpts>,
+    compiler: &PrimaryCodegen,
+    loc: Srcloc,
+    list_head: Rc<BodyForm>
+) -> Result<Callable, CompileErr> {
+    let list_head_borrowed: &BodyForm = list_head.borrow();
+    let name = get_call_name(loc.clone(), list_head_borrowed.clone())?;
+    get_callable(opts, compiler, loc.clone(), name.clone())
+}
+
+fn replace_inline_body(
+    allocator: &mut Allocator,
+    runner: Rc<dyn TRunProgram>,
+    opts: Rc<dyn CompilerOpts>,
+    compiler: &PrimaryCodegen,
+    loc: Srcloc,
+    inline: &InlineFunction,
+    args: &Vec<Rc<BodyForm>>,
+    expr: Rc<BodyForm>,
+) -> Result<Rc<BodyForm>, CompileErr> {
+    let arg_str_vec: Vec<String> = args.iter().map(|x| x.to_sexp().to_string()).collect();
+
+    println!("replace_inline_body {} function {} expr {} args {:?}", SExp::Atom(loc.clone(), inline.name.to_vec()).to_string(), inline.to_sexp().to_string(), expr.to_sexp().to_string(), arg_str_vec);
+
+    match expr.borrow() {
+        BodyForm::Let(l, _, bindings, body) => Err(CompileErr(
+            loc.clone(),
+            "let binding should have been hoisted before optimization".to_string(),
+        )),
+        BodyForm::Call(l, call_args) => {
+            let mut new_args = Vec::new();
+            for i in 0..call_args.len() {
+                if i == 0 {
+                    new_args.push(call_args[i].clone());
+                } else {
+                    let replaced =
+                        replace_inline_body(
+                            allocator,
+                            runner.clone(),
+                            opts.clone(),
+                            compiler,
+                            call_args[i].loc(),
+                            inline,
+                            &args.clone(),
+                            call_args[i].clone()
+                        )?;
+                    new_args.push(replaced);
+                }
+            }
+            // If the called function is an inline, we'll expand it here.
+            // This is so we can preserve the context of argument expressions
+            // so no new mapping is needed.  This solves a number of problems
+            // with the previous implementation.
+            //
+            // If it's a macro we'll expand it here so we can recurse and
+            // determine whether an inline is the next level.
+            match get_inline_callable(opts.clone(), compiler, l.clone(), call_args[0].clone())? {
+                Callable::CallInline(_, new_inline) => {
+                    replace_in_inline(
+                        allocator,
+                        runner,
+                        opts.clone(),
+                        compiler,
+                        l.clone(),
+                        &new_inline,
+                        &new_args
+                    )
+                },
+                Callable::CallMacro(_, macro_body) => {
+                    panic!("expand macro and reprocess");
+                },
+                _ => {
+                    Ok(Rc::new(BodyForm::Call(l.clone(), new_args)))
+                }
+            }
+        },
+        BodyForm::Value(SExp::Atom(_, a)) => arg_lookup(inline.args.clone(), 0, args, a.clone())
+            .map(|x| Ok(x.clone()))
+            .unwrap_or_else(|| Ok(expr.clone())),
+        _ => Ok(expr.clone())
+    }
+}
+
 pub fn replace_in_inline(
     allocator: &mut Allocator,
     runner: Rc<dyn TRunProgram>,
     opts: Rc<dyn CompilerOpts>,
     compiler: &PrimaryCodegen,
     loc: Srcloc,
-    name: Vec<u8>,
     inline: &InlineFunction,
-    args_: Option<&Vec<Rc<BodyForm>>>,
-) -> Result<CompiledCode, CompileErr> {
-    let mut arg_lookup = HashMap::new();
-    let args_type = classify_inline_args(loc.clone(), inline.args.clone())?;
-
-    let args = args_
-        .map(|x| x.clone())
-        .unwrap_or_else(|| synthesize_args(inline.args.clone()));
-
-    let make_consed_args = || {
-        let mut arg_form = Rc::new(BodyForm::Quoted(SExp::Nil(loc.clone())));
-
-        for i_reverse in 0..args.len() {
-            let i = args.len() - i_reverse - 1;
-            arg_form = Rc::new(BodyForm::Call(
-                loc.clone(),
-                vec![
-                    Rc::new(BodyForm::Value(SExp::atom_from_string(
-                        loc.clone(),
-                        &"c".to_string(),
-                    ))),
-                    args[i].clone(),
-                    arg_form.clone(),
-                ],
-            ));
-        }
-
-        arg_form
-    };
-
-    match args_type {
-        InlineArgsType::Whole(name) => {
-            // The given name receives a consed set of all arguments.
-            let arg_form = make_consed_args();
-            arg_lookup.insert(name.clone(), arg_form.clone());
-        }
-        InlineArgsType::List(alist) => {
-            // Most common case: arguments are presented as a list:
-            // we take each argument and put it in arg_lookup.
-            if alist.len() != args.len() {
-                return Err(CompileErr(loc.clone(), format!("wrong number of parameters for argument list of function {}, want {} given {}", decode_string(&name), alist.len(), args.len())));
-            }
-
-            arg_lookup = create_args_alist(loc.clone(), &alist, &args);
-        }
-    }
-
-    let final_expr = replace_in_inline_expr(loc.clone(), &arg_lookup, inline.body.clone())?;
-    generate_expr_code(allocator, runner, opts, compiler, final_expr)
+    args: &Vec<Rc<BodyForm>>,
+) -> Result<Rc<BodyForm>, CompileErr> {
+    let arg_str_vec: Vec<String> = args.iter().map(|x| x.to_sexp().to_string()).collect();
+    let res = replace_inline_body(
+        allocator,
+        runner,
+        opts,
+        compiler,
+        loc.clone(),
+        inline,
+        args,
+        inline.body.clone(),
+    )?;
+    println!("replace_in_inline (defun-inline {} {} {}) with args {:?} gives {}", SExp::Atom(loc.clone(), inline.name.clone()).to_string(), inline.args.to_string(), inline.to_sexp().to_string(), arg_str_vec, res.to_sexp().to_string());
+    Ok(res)
 }

--- a/src/compiler/inline.rs
+++ b/src/compiler/inline.rs
@@ -27,7 +27,7 @@ fn apply_fn(loc: Srcloc, name: String, expr: Rc<BodyForm>) -> Rc<BodyForm> {
         vec![
             Rc::new(BodyForm::Value(SExp::atom_from_string(
                 loc.clone(),
-                &"@".to_string(),
+                &name,
             ))),
             expr
         ],
@@ -88,15 +88,19 @@ fn pick_value_from_arg_element(match_args: Rc<SExp>, provided: Rc<BodyForm>, app
                 apply_fn(l.clone(), "r".to_string(), x.clone())
             }, name.clone());
 
-            match (matched_a, matched_b) {
+            let result = match (matched_a, matched_b) {
                 (Some(a), _) => Some(a),
                 (_, Some(b)) => Some(b),
                 _ => None
-            }
+            };
+
+            println!("pick_value_from_arg_element args {} provided {} name {} result {}", match_args.to_string(), provided.to_sexp().to_string(), SExp::Atom(l.clone(), name.clone()).to_string(), result.as_ref().map(|x| x.to_sexp().to_string()).unwrap_or_else(|| "None".to_string()));
+            result
         },
-        SExp::Atom(_, a) => {
+        SExp::Atom(l, a) => {
             if *a == name {
-                Some(provided)
+                println!("pick_value_from_arg_element args {} provided {} name {}", match_args.to_string(), apply(provided.clone()).to_sexp().to_string(), SExp::Atom(l.clone(), name.clone()).to_string());
+                Some(apply(provided))
             } else {
                 None
             }

--- a/src/compiler/rename.rs
+++ b/src/compiler/rename.rs
@@ -2,7 +2,7 @@ use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use crate::compiler::comptypes::{Binding, BodyForm, CompileErr, CompileForm, HelperForm};
+use crate::compiler::comptypes::{Binding, BodyForm, CompileErr, CompileForm, HelperForm, LetFormKind};
 use crate::compiler::gensym::gensym;
 use crate::compiler::sexp::{decode_string, SExp};
 
@@ -136,7 +136,7 @@ fn make_binding_unique(b: &Binding) -> (Vec<u8>, Binding) {
 fn rename_in_bodyform(namemap: &HashMap<Vec<u8>, Vec<u8>>, b: Rc<BodyForm>) -> BodyForm {
     let names: Vec<String> = namemap.iter().map(|x| decode_string(x.0)).collect();
     match b.borrow() {
-        BodyForm::Let(l, bindings, body) => {
+        BodyForm::Let(l, kind, bindings, body) => {
             let new_bindings = bindings
                 .iter()
                 .map(|b| {
@@ -148,8 +148,8 @@ fn rename_in_bodyform(namemap: &HashMap<Vec<u8>, Vec<u8>>, b: Rc<BodyForm>) -> B
                 })
                 .collect();
             let new_body = rename_in_bodyform(namemap, body.clone());
-            BodyForm::Let(l.clone(), new_bindings, Rc::new(new_body.clone()))
-        }
+            BodyForm::Let(l.clone(), kind.clone(), new_bindings, Rc::new(new_body.clone()))
+        },
 
         BodyForm::Quoted(atom) => match atom.borrow() {
             SExp::Atom(l, n) => match namemap.get(n) {
@@ -177,9 +177,41 @@ fn rename_in_bodyform(namemap: &HashMap<Vec<u8>, Vec<u8>>, b: Rc<BodyForm>) -> B
     }
 }
 
+pub fn desugar_sequential_let_bindings(
+    bindings: &Vec<Rc<Binding>>,
+    body: &BodyForm,
+    n: usize // Zero is for post-termination
+) -> BodyForm {
+    if n == 0 {
+        body.clone()
+    } else {
+        let want_binding = bindings[n - 1].clone();
+        desugar_sequential_let_bindings(
+            bindings,
+            &BodyForm::Let(
+                want_binding.loc(),
+                LetFormKind::Parallel,
+                vec!(want_binding),
+                Rc::new(body.clone())
+            ),
+            n - 1
+        )
+    }
+}
+
 fn rename_args_bodyform(b: &BodyForm) -> BodyForm {
     match b.borrow() {
-        BodyForm::Let(l, bindings, body) => {
+        BodyForm::Let(l, LetFormKind::Sequential, bindings, body) => {
+            // Renaming a sequential let is exactly as if the bindings were
+            // nested in separate parallel lets.
+            let new_body = rename_args_bodyform(
+                &desugar_sequential_let_bindings(&bindings, body, bindings.len())
+            );
+            println!("desugared let stack: {}", new_body.to_sexp().to_string());
+            new_body
+        },
+
+        BodyForm::Let(l, LetFormKind::Parallel, bindings, body) => {
             let renames: Vec<(Vec<u8>, Binding)> = bindings
                 .iter()
                 .map(|x| make_binding_unique(x.borrow()))
@@ -205,7 +237,7 @@ fn rename_args_bodyform(b: &BodyForm) -> BodyForm {
                 })
                 .collect();
             let locally_renamed_body = rename_in_bodyform(&local_namemap, body.clone());
-            let new_body = BodyForm::Let(l.clone(), new_bindings, Rc::new(locally_renamed_body));
+            let new_body = BodyForm::Let(l.clone(), LetFormKind::Parallel, new_bindings, Rc::new(locally_renamed_body));
             new_body
         }
 

--- a/src/py/api.rs
+++ b/src/py/api.rs
@@ -30,8 +30,6 @@ fn compile_clvm(
                 path_string = path_string + ".clvm";
             };
 
-        let _ = print!("input {:?} trying {}\n", input_path, path_string);
-
         clvmc::compile_clvm(
             &path_string,
             &output_path,

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -178,9 +178,11 @@ fn run_test_8() {
 #[test]
 fn run_inlines() {
     let result = run_string(
-        &"(mod (a) (defun-inline F (x) (+ x 1)) (defun-inline G (x) (* x 2)) (G (F a)))".to_string(),
+        &"(mod (a) (defun-inline F (x) (+ x 1)) (defun-inline G (x) (* x 2)) (G (F a)))"
+            .to_string(),
         &"(13)".to_string(),
-    ).unwrap();
+    )
+    .unwrap();
     assert_eq!(result.to_string(), "28".to_string());
 }
 

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -182,8 +182,145 @@ fn run_inlines() {
             .to_string(),
         &"(13)".to_string(),
     )
-    .unwrap();
+        .unwrap();
     assert_eq!(result.to_string(), "28".to_string());
+}
+
+#[test]
+fn run_inlines_2() {
+    let result = run_string(
+        &"(mod (a b) (defun-inline F (x y) (+ x y)) (defun-inline G (x y) (- y x)) (defun-inline H (x y) (* x y)) (H (F a b) (G a b)))"
+            .to_string(),
+        &"(103 107)".to_string(),
+    )
+        .unwrap();
+    // H (103 + 107) (108 - 104)
+    // 210 * 4
+    // 840
+    assert_eq!(result.to_string(), "840".to_string());
+}
+
+#[test]
+fn run_test_at_form() {
+    let result = run_string(
+        &"(mod (a b) (- (@ 11) (@ 5)))".to_string(),
+        &"(51 107)".to_string(),
+    ).unwrap();
+    assert_eq!(result.to_string(), "56".to_string());
+}
+
+#[test]
+fn run_test_intermediate_let_1() {
+    let result = run_string(
+        &indoc! {"
+            (mod (a)
+                (defun-inline letbinding_$_264 args args)
+                (letbinding_$_264 (r @) (+ a 1))
+                )
+        "}.to_string(),
+        &"(100)".to_string(),
+    ).unwrap();
+    assert_eq!(result.to_string(), "((100) 101)".to_string());
+}
+
+#[test]
+fn run_test_intermediate_let_1_1() {
+    let result = run_string(
+        &indoc! {"
+            (mod (a)
+                (defun-inline letbinding_$_265 args args)
+                (defun letbinding_$_264 ((a) x) (letbinding_$_265 (c (c a ()) (c x ())) (+ x 1)))
+                (letbinding_$_264 (r @) (+ a 1))
+                )
+        "}.to_string(),
+        &"(100)".to_string(),
+    ).unwrap();
+    assert_eq!(result.to_string(), "(((100) 101) 102)".to_string());
+}
+
+#[test]
+fn run_test_intermediate_let_1_2() {
+    let result = run_string(
+        &indoc! {"
+            (mod (a)
+                (defun letbinding_$_265 args args)
+                (defun letbinding_$_264 ((a) x) (letbinding_$_265 (c (c a ()) (c x ())) (+ x 1)))
+                (letbinding_$_264 (r @) (+ a 1))
+                )
+        "}.to_string(),
+        &"(100)".to_string(),
+    ).unwrap();
+    assert_eq!(result.to_string(), "(((100) 101) 102)".to_string());
+}
+
+#[test]
+fn run_test_intermediate_let_1_3() {
+    let result = run_string(
+        &indoc! {"
+            (mod (a)
+                (defun-inline letbinding_$_265 args args)
+                (defun letbinding_$_264 ((a) x) (letbinding_$_265 (c (c a ()) (c x ())) (+ x 1)))
+                (letbinding_$_264 (r @) (+ a 1))
+                )
+        "}.to_string(),
+        &"(100)".to_string(),
+    ).unwrap();
+    assert_eq!(result.to_string(), "(((100) 101) 102)".to_string());
+}
+
+#[test]
+fn run_test_intermediate_let_1_4() {
+    let result = run_string(
+        &indoc! {"
+            (mod (a)
+                (defun letbinding_$_265 args args)
+                (defun-inline letbinding_$_264 ((a) x) (letbinding_$_265 (c (c a ()) (c x ())) (+ x 1)))
+                (letbinding_$_264 (r @) (+ a 1))
+                )
+        "}.to_string(),
+        &"(100)".to_string(),
+    ).unwrap();
+    assert_eq!(result.to_string(), "(((100) 101) 102)".to_string());
+}
+
+#[test]
+fn run_test_intermediate_let_2() {
+    let result = run_string(
+        &indoc! {"
+            (mod (a)
+                (defun-inline letbinding_$_265 args args)
+                (defun-inline letbinding_$_264 ((a) x) (letbinding_$_265 (c (c a ()) (c x ())) (+ x 1)))
+                (letbinding_$_264 (r @) (+ a 1))
+                )
+        "}.to_string(),
+        &"(100)".to_string(),
+    ).unwrap();
+    assert_eq!(result.to_string(), "(((100) 101) 102)".to_string());
+}
+
+#[test]
+fn run_test_intermediate_let_final() {
+    let result = run_string(
+        &indoc! {"
+            (mod (a)
+                (defun-inline letbinding_$_265 (((a) x_$_263) y) (+ x_$_263 y))
+                (defun-inline letbinding_$_264 ((a) x) (letbinding_$_265 (c (c a ()) (+ x 1)) (+ x 1)))
+                (letbinding_$_264 (r @) (+ a 1))
+                )
+        "}.to_string(),
+        &"(100)".to_string(),
+    ).unwrap();
+    assert_eq!(result.to_string(), "202".to_string());
+}
+
+#[test]
+fn run_test_let_star() {
+    let result = run_string(
+        &"(mod (a) (let* ((x (+ a 1)) (y (+ x 1))) (+ x y)))".to_string(),
+        &"(100)".to_string(),
+    )
+        .unwrap();
+    assert_eq!(result.to_string(), "202".to_string());
 }
 
 #[test]

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -176,6 +176,15 @@ fn run_test_8() {
 }
 
 #[test]
+fn run_inlines() {
+    let result = run_string(
+        &"(mod (a) (defun-inline F (x) (+ x 1)) (defun-inline G (x) (* x 2)) (G (F a)))".to_string(),
+        &"(13)".to_string(),
+    ).unwrap();
+    assert_eq!(result.to_string(), "28".to_string());
+}
+
+#[test]
 fn run_test_9() {
     let result = run_string(
         &"(mod (a) (defun f (i) (let ((x (not i)) (y (* i 2))) (+ x y))) (f a))".to_string(),

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -334,6 +334,39 @@ fn run_test_let_star_3_deep() {
 }
 
 #[test]
+fn run_test_normal_with_macro_call() {
+    let result = run_string(
+        &"(mod (a) (defun test-value (a n) (if (- a n) 9999 1111)) (c (test-value a 3) (test-value a 2)))".to_string(),
+        &"(3)".to_string()
+    ).unwrap();
+    assert_eq!(result.to_string(), "(1111 . 9999)".to_string());
+}
+
+#[test]
+fn run_test_inline_with_macro_call() {
+    let result = run_string(
+        &"(mod (X) (defun-inline test-value (a n) (if (- a n) 9999 1111)) (c (test-value X 3) (test-value X 2)))".to_string(),
+        &"(3)".to_string()
+    ).unwrap();
+    assert_eq!(result.to_string(), "(1111 . 9999)".to_string());
+}
+
+/*
+ * - TODO: Ensure that a compileform name inlined and shadowed in a macro doesn't
+ *   disrupt macro execution.
+ *   ... i'll have to think about how to handle this.
+ * /
+#[test]
+fn run_test_inline_with_macro_call_tricky_naming() {
+    let result = run_string(
+        &"(mod (a) (defun-inline test-value (a n) (if (- a n) 9999 1111)) (c (test-value a 3) (test-value a 2)))".to_string(),
+        &"(3)".to_string()
+    ).unwrap();
+    assert_eq!(result.to_string(), "(1111 . 9999)".to_string());
+}
+ */
+
+#[test]
 fn run_test_9() {
     let result = run_string(
         &"(mod (a) (defun f (i) (let ((x (not i)) (y (* i 2))) (+ x y))) (f a))".to_string(),

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -182,7 +182,7 @@ fn run_inlines() {
             .to_string(),
         &"(13)".to_string(),
     )
-        .unwrap();
+    .unwrap();
     assert_eq!(result.to_string(), "28".to_string());
 }
 
@@ -205,7 +205,8 @@ fn run_test_at_form() {
     let result = run_string(
         &"(mod (a b) (- (@ 11) (@ 5)))".to_string(),
         &"(51 107)".to_string(),
-    ).unwrap();
+    )
+    .unwrap();
     assert_eq!(result.to_string(), "56".to_string());
 }
 
@@ -217,9 +218,11 @@ fn run_test_intermediate_let_1() {
                 (defun-inline letbinding_$_264 args args)
                 (letbinding_$_264 (r @) (+ a 1))
                 )
-        "}.to_string(),
+        "}
+        .to_string(),
         &"(100)".to_string(),
-    ).unwrap();
+    )
+    .unwrap();
     assert_eq!(result.to_string(), "((100) 101)".to_string());
 }
 
@@ -232,9 +235,11 @@ fn run_test_intermediate_let_1_1() {
                 (defun letbinding_$_264 ((a) x) (letbinding_$_265 (c (c a ()) (c x ())) (+ x 1)))
                 (letbinding_$_264 (r @) (+ a 1))
                 )
-        "}.to_string(),
+        "}
+        .to_string(),
         &"(100)".to_string(),
-    ).unwrap();
+    )
+    .unwrap();
     assert_eq!(result.to_string(), "(((100) 101) 102)".to_string());
 }
 
@@ -247,9 +252,11 @@ fn run_test_intermediate_let_1_2() {
                 (defun letbinding_$_264 ((a) x) (letbinding_$_265 (c (c a ()) (c x ())) (+ x 1)))
                 (letbinding_$_264 (r @) (+ a 1))
                 )
-        "}.to_string(),
+        "}
+        .to_string(),
         &"(100)".to_string(),
-    ).unwrap();
+    )
+    .unwrap();
     assert_eq!(result.to_string(), "(((100) 101) 102)".to_string());
 }
 
@@ -262,9 +269,11 @@ fn run_test_intermediate_let_1_3() {
                 (defun letbinding_$_264 ((a) x) (letbinding_$_265 (c (c a ()) (c x ())) (+ x 1)))
                 (letbinding_$_264 (r @) (+ a 1))
                 )
-        "}.to_string(),
+        "}
+        .to_string(),
         &"(100)".to_string(),
-    ).unwrap();
+    )
+    .unwrap();
     assert_eq!(result.to_string(), "(((100) 101) 102)".to_string());
 }
 
@@ -319,7 +328,7 @@ fn run_test_let_star_2_deep() {
         &"(mod (a) (let* ((x (+ a 1)) (y (+ x 1))) (+ x y)))".to_string(),
         &"(100)".to_string(),
     )
-        .unwrap();
+    .unwrap();
     assert_eq!(result.to_string(), "203".to_string());
 }
 
@@ -329,7 +338,7 @@ fn run_test_let_star_3_deep() {
         &"(mod (a) (let* ((x (+ a 1)) (y (+ x 1)) (z (* a y))) (+ x y z)))".to_string(),
         &"(100)".to_string(),
     )
-        .unwrap();
+    .unwrap();
     assert_eq!(result.to_string(), "10403".to_string());
 }
 

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -314,13 +314,23 @@ fn run_test_intermediate_let_final() {
 }
 
 #[test]
-fn run_test_let_star() {
+fn run_test_let_star_2_deep() {
     let result = run_string(
         &"(mod (a) (let* ((x (+ a 1)) (y (+ x 1))) (+ x y)))".to_string(),
         &"(100)".to_string(),
     )
         .unwrap();
     assert_eq!(result.to_string(), "203".to_string());
+}
+
+#[test]
+fn run_test_let_star_3_deep() {
+    let result = run_string(
+        &"(mod (a) (let* ((x (+ a 1)) (y (+ x 1)) (z (* a y))) (+ x y z)))".to_string(),
+        &"(100)".to_string(),
+    )
+        .unwrap();
+    assert_eq!(result.to_string(), "10403".to_string());
 }
 
 #[test]

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -304,13 +304,13 @@ fn run_test_intermediate_let_final() {
         &indoc! {"
             (mod (a)
                 (defun-inline letbinding_$_265 (((a) x_$_263) y) (+ x_$_263 y))
-                (defun-inline letbinding_$_264 ((a) x) (letbinding_$_265 (c (c a ()) (+ x 1)) (+ x 1)))
+                (defun-inline letbinding_$_264 ((a) x) (letbinding_$_265 (c (c a ()) (c x ())) (+ x 1)))
                 (letbinding_$_264 (r @) (+ a 1))
                 )
         "}.to_string(),
         &"(100)".to_string(),
     ).unwrap();
-    assert_eq!(result.to_string(), "202".to_string());
+    assert_eq!(result.to_string(), "203".to_string());
 }
 
 #[test]
@@ -320,7 +320,7 @@ fn run_test_let_star() {
         &"(100)".to_string(),
     )
         .unwrap();
-    assert_eq!(result.to_string(), "202".to_string());
+    assert_eq!(result.to_string(), "203".to_string());
 }
 
 #[test]


### PR DESCRIPTION
A complete rewrite of inline.rs which simplifies it and ensures that expressions from the enclosing host environment pass through.  inlining now performs recursive inline expansions on its own rather than throwing them back to the parent code generator so that they maintain continuity.
Added several tests which exercise both recursive inline expansions and the new let* binding, which allows each subsequent binding to depend on the last.