### PR TITLE
20230109 optimize fix use checking

### DIFF
--- a/resources/tests/bridge-includes/condition_codes.clib
+++ b/resources/tests/bridge-includes/condition_codes.clib
@@ -1,0 +1,38 @@
+; See chia/types/condition_opcodes.py
+
+(
+    (defconstant AGG_SIG_UNSAFE 49)
+    (defconstant AGG_SIG_ME 50)
+
+    ; the conditions below reserve coin amounts and have to be accounted for in output totals
+
+    (defconstant CREATE_COIN 51)
+    (defconstant RESERVE_FEE 52)
+
+    ; the conditions below deal with announcements, for inter-coin communication
+
+    ; coin announcements
+    (defconstant CREATE_COIN_ANNOUNCEMENT 60)
+    (defconstant ASSERT_COIN_ANNOUNCEMENT 61)
+
+    ; puzzle announcements
+    (defconstant CREATE_PUZZLE_ANNOUNCEMENT 62)
+    (defconstant ASSERT_PUZZLE_ANNOUNCEMENT 63)
+
+    ; the conditions below let coins inquire about themselves
+
+    (defconstant ASSERT_MY_COIN_ID 70)
+    (defconstant ASSERT_MY_PARENT_ID 71)
+    (defconstant ASSERT_MY_PUZZLEHASH 72)
+    (defconstant ASSERT_MY_AMOUNT 73)
+
+    ; the conditions below ensure that we're "far enough" in the future
+
+    ; wall-clock time
+    (defconstant ASSERT_SECONDS_RELATIVE 80)
+    (defconstant ASSERT_SECONDS_ABSOLUTE 81)
+
+    ; block index
+    (defconstant ASSERT_HEIGHT_RELATIVE 82)
+    (defconstant ASSERT_HEIGHT_ABSOLUTE 83)
+)

--- a/resources/tests/bridge-includes/curry.clib
+++ b/resources/tests/bridge-includes/curry.clib
@@ -1,0 +1,137 @@
+(
+  ;; The code below is used to calculate of the tree hash of a curried function
+  ;; without actually doing the curry, and using other optimization tricks
+  ;; like unrolling `sha256tree`.
+
+  (defconstant TWO 2)
+  (defconstant constant-tree (0x4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a 0x9dcf97a184f32623d11a73124ceb99a5709b083721e878a16d78f596718ba7b2 0x02a12871fee210fb8619291eaea194581cbd2531e4b23759d225f6806923f63222 0x02a8d5dd63fba471ebcb1f3e8f7c1e1879b7152a6e7298a91ce119a63400ade7c5))
+
+  ; I looked into calculating the values of `constant-tree` because it's pretty easy to code-golf
+  ; out an implementation that produces the values cheaper than just inlining them. The problem is,
+  ; when do we calculate them? If there were a way to calculate it "before main" and include it in
+  ; the globally-accessible constant table, we could do that. But we can't which means to be optimal,
+  ; client code should call the "build table" code once, then pass it around to anyone that wants to
+  ; call `curry` or `curry2`. This is pretty intrusive, so for now we'll just use the existing
+  ; global constant infrastructure, and include it as a fixed table so the tree of four values will
+  ; appear in all code that includes this file, and it will compress better in generators.
+
+  (defun-inline sha256_one _noargs (f constant-tree))
+  (defun-inline sha256_one_one _noargs (f (r constant-tree)))
+  (defun-inline two_sha256_one_a_kw _noargs (f (r (r constant-tree))))
+  (defun-inline two_sha256_one_c_kw _noargs (f (r (r (r constant-tree)))))
+
+  ;; this returns the sha256 tree hash of expression F = `((q . a1) a2)`
+  (defun hash-expression-F (a1 a2)
+         (sha256 TWO (sha256 TWO (sha256_one_one) a1)
+                 (sha256 TWO a2 (sha256_one)))
+  )
+
+  ;; Given the tree hash `environment-hash` of an environment tree E
+  ;; and the tree hash `parameter-hash` of a constant parameter P
+  ;; return the tree hash of the tree corresponding to
+  ;; `(c (q . P) E)`
+  ;; This is the new environment tree with the addition parameter P curried in.
+  ;;
+  ;; Note that `(c (q . P) E)` = `(c . ((q . P) . (E . 0)))`
+
+  (defun-inline update-hash-for-parameter-hash (parameter-hash environment-hash)
+     (sha256 (two_sha256_one_c_kw) (hash-expression-F parameter-hash environment-hash))
+  )
+
+  ;; Given the tree hash `environment-hash` of an environment tree E
+  ;; and the tree hash `mod-hash` of a mod M
+  ;; return the tree hash of the tree corresponding to
+  ;; `(a (q . M) E)`
+  ;; This is the hash of a new function that adopts the new environment E.
+  ;; This is used to build of the tree hash of a curried function.
+  ;;
+  ;; Note that `(a (q . M) E)` = `(a . ((q . M)  . (E . 0)))`
+
+  (defun-inline tree-hash-of-apply (mod-hash environment-hash)
+     (sha256 (two_sha256_one_a_kw) (hash-expression-F mod-hash environment-hash))
+  )
+
+  ;; This function recursively calls `update-hash-for-parameter-hash`
+
+  (defun calculate-hash-of-curried-parameters (curry-parameter-hashes)
+     (if curry-parameter-hashes
+      (update-hash-for-parameter-hash (f curry-parameter-hashes) (calculate-hash-of-curried-parameters (r curry-parameter-hashes)))
+      (sha256_one_one)
+     )
+  )
+
+  ;; mod-hash:
+  ;;   the hash of a puzzle function, ie. a `mod`
+  ;;
+  ;; curry-parameter-hashes:
+  ;;   a list of pre-hashed trees representing parameters to be curried into the puzzle.
+  ;;
+  ;; we return the hash of the curried expression
+  ;;   (a (q . mod-hash) (c (cp1 (c cp2 (c ... 1)...))))
+  ;;
+  ;; Note that from a user's perspective the hashes passed in here aren't simply
+  ;; the hashes of the desired parameters, but their treehash representation since
+  ;; that's the form we're assuming they take in the acutal curried program.
+
+  ;; inline functions that take varargs don't seem to work, so we can't inline `curry`
+
+  (defun curry_hashes (mod-hash . curry-parameter-hashes)
+     (tree-hash-of-apply mod-hash
+                         (calculate-hash-of-curried-parameters curry-parameter-hashes))
+  )
+
+
+  ;; this is included for future compilers that handle it properly. If you get weird
+  ;; errors using this, it may be your tooling. Use `curry` above instead, or inline manually.
+
+  (defun-inline curry_hashes_inline (mod-hash . curry-parameter-hashes)
+     (tree-hash-of-apply mod-hash
+                         (calculate-hash-of-curried-parameters curry-parameter-hashes))
+  )
+
+  ;; `curry_mod_hashes_inline` takes exactly two parameters rather than varags, and it can be inlined
+
+  (defun-inline curry_mod_hashes_inline (mod-hash curry-parameter-hashes)
+     (tree-hash-of-apply mod-hash
+                         (calculate-hash-of-curried-parameters curry-parameter-hashes))
+  )
+
+  (defmacro curry_mod_hash_with_hashes (mod_hash . curry_parameter_hashes)
+    (qq
+      (sha256
+        ; apply
+        (two_sha256_one_a_kw)
+        (sha256 TWO
+          ; func
+          (sha256 TWO
+            (sha256_one_one)
+            (unquote mod_hash)
+          )
+          (sha256 TWO
+            ; args
+            (unquote (c build_pre_hashed_environment curry_parameter_hashes))
+            (sha256_one)
+          )
+        )
+      )
+    )
+  )
+
+  (defmacro build_pre_hashed_environment curry_parameter_hashes
+    (qq
+      (sha256
+        (two_sha256_one_c_kw)
+        (sha256 TWO
+          (sha256 TWO
+            (sha256_one_one)
+            (unquote (f curry_parameter_hashes))
+          )
+          (sha256 TWO
+            (unquote (if (r curry_parameter_hashes) (c build_pre_hashed_environment (r curry_parameter_hashes)) (q . (sha256_one_one))))
+            (sha256_one)
+          )
+        )
+      )
+    )
+  )
+)

--- a/resources/tests/bridge-includes/merkle_utils.clib
+++ b/resources/tests/bridge-includes/merkle_utils.clib
@@ -1,0 +1,19 @@
+(
+
+  (defun simplify_merkle_proof_after_leaf (leaf_hash (bitpath . hashes_path))
+    (if hashes_path
+        (simplify_merkle_proof_after_leaf
+            (if (logand 1 bitpath)
+                (sha256 0x02 (f hashes_path) leaf_hash)
+                (sha256 0x02 leaf_hash (f hashes_path))
+            )
+            (c (lsh bitpath -1) (r hashes_path))
+        )
+        leaf_hash
+     )
+  )
+
+  (defun-inline simplify_merkle_proof (leaf proof)
+    (simplify_merkle_proof_after_leaf (sha256 0x01 leaf) proof)
+  )
+)

--- a/resources/tests/bridge-includes/sha256tree.clib
+++ b/resources/tests/bridge-includes/sha256tree.clib
@@ -1,0 +1,7 @@
+(
+  ; takes a lisp tree and returns the hash of it
+  (defun sha256tree (TREE)
+        (if (l TREE)
+            (sha256 2 (sha256tree (f TREE)) (sha256tree (r TREE)))
+            (sha256 1 TREE)))
+)

--- a/resources/tests/bridge-includes/utility_macros.clib
+++ b/resources/tests/bridge-includes/utility_macros.clib
@@ -1,0 +1,55 @@
+(
+  (defmacro assert items
+      (if (r items)
+          (list if (f items) (c assert (r items)) (q . (x)))
+          (f items)
+      )
+  )
+
+  (defmacro or ARGS
+      (if ARGS
+          (qq (if (unquote (f ARGS))
+              1
+              (unquote (c or (r ARGS)))
+          ))
+      0)
+  )
+
+  (defmacro and ARGS
+      (if ARGS
+          (qq (if (unquote (f ARGS))
+              (unquote (c and (r ARGS)))
+              ()
+              ))
+          1)
+  )
+
+  (defmacro prepend items
+      (if (r items)
+          (list if (f items) (c assert (r items)) (q . (x)))
+          (f items)
+      )
+  )
+
+  ; take two lists and merge them into one
+  (defun merge_list (list_a list_b)
+    (if list_a
+      (c (f list_a) (merge_list (r list_a) list_b))
+      list_b
+    )
+  )
+
+  (defun-inline min (a b)
+    (i (> a b)
+       b
+       a
+    )
+  )
+
+  (defun-inline max (a b)
+    (i (> a b)
+       a
+       b
+    )
+  )
+)

--- a/resources/tests/optimization/merkle_tree_a2c.clsp
+++ b/resources/tests/optimization/merkle_tree_a2c.clsp
@@ -1,0 +1,17 @@
+; This is an authorization-to-conditions function for use with p2_graftroot_or_taproot
+(mod
+  (
+      root  ; authorization
+      delegated_puzzle_hash
+      proof_of_inclusion ; a2c_args
+  )
+
+  (include *standard-cl-22*)
+
+  (include merkle_utils.clib)
+  (include utility_macros.clib)
+
+  (assert (= (simplify_merkle_proof delegated_puzzle_hash proof_of_inclusion) root)
+    ()
+  )
+)

--- a/resources/tests/optimization/validation_taproot.clsp
+++ b/resources/tests/optimization/validation_taproot.clsp
@@ -1,0 +1,277 @@
+; This puzzle is intended to go inside of a taproot section of a standard inner puzzle. It does not, however,
+; concern itself with re-creating the coin it is a part of. Since this is likely inside of a singleton, this will result
+; in an error unless some higher puzzle takes care of recreation.
+;
+; Curried into this puzzle are 2 things:
+; 1) Some info for constructing a bridge. A bridge from this puzzle's perspective is a singleton(state_layer(*)) puzzle
+;    stack, where the state_layer has a metadata of a single "height" integer and the updater accepts a solution of
+;    ((new_metadata new_metadata_updater_ph) conditions) - likely `11`.
+;
+; 2) A root of "validations". Each validation is (height . puzzle_hash) pair which signifies a vote on a payment to be
+;    made mapped to a height on another blockchain (for example). The validator will make an announcement such that the
+;    bridge's height is updated to the maximum height of the validations revealed + 1 (the next height to be validated)
+;    and the bridge creates a coin with amount 0 and the specified puzzle hash.
+;
+;    The validations are stored in a binary tree and to spend this coin, one must provide a reveal of that binary tree
+;    all the way down to the validation pairs within. However, if the spender does not wish to announce all of the pairs
+;    in the tree, the can instead just reveal the necessary branch hashes to prove the other pairs' inclusion in the
+;    curried in root. For example, consider the following validation tree:
+;                                               0xVALIDATION_ROOT
+;                                              /                 \
+;                                             /                   \
+;                                           0xbranch1              0xbranch2
+;                                          /         \            /         \
+;                                   (0 . 0x...) (1 . 0x...)  (2 . 0x...) (3 . 0x...)
+;
+;    If the spender only wished to validate heights 0-1, they would provide the following reveal:
+;                                               0xVALIDATION_ROOT
+;                                              /                 \
+;                                             /                   \
+;                                           0xbranch1              0xbranch2
+;                                          /         \
+;                                   (0 . 0x...) (1 . 0x...)
+;
+;    And later, if they wished to validate height 2, they would provide the following tree:
+;                                               0xVALIDATION_ROOT
+;                                              /                 \
+;                                             /                   \
+;                                           0xbranch1              0xbranch2
+;                                                                 /         \
+;                                                           (2 . 0x...) 0xpair_hash3
+(mod
+  (
+      BRIDGE_SINGLETON_STRUCT
+      NFT_STATE_LAYER_MOD_HASH  ; The metadata should be a single integer and the updater is supplied in solution
+      VALIDATION_ROOT  ; A binary tree of (height . secure_the_bag_ph) pairs
+      bridge_height
+      bridge_metadata_updater_hash
+      bridge_inner_puzhash
+      bridge_amount
+      validations_proof  ; A reveal of the validation tree, with un-needed pairs already pre-hashed
+  )
+
+  (include *standard-cl-22*)
+
+  (include condition_codes.clib)
+  (include curry.clib)
+  (include sha256tree.clib)
+  (include utility_macros.clib)
+  (defconstant ONE 1)
+
+  (defun-inline calculate_singleton_puzzle_hash
+    (
+      (@ BRIDGE_SINGLETON_STRUCT
+        (SINGLETON_MOD_HASH . (LAUNCHER_ID . SINGLETON_LAUNCHER_HASH))
+      )
+      NFT_STATE_LAYER_MOD_HASH
+      bridge_height
+      bridge_metadata_updater_hash
+      bridge_inner_puzhash
+    )
+
+    (curry_mod_hash_with_hashes SINGLETON_MOD_HASH
+      (sha256tree BRIDGE_SINGLETON_STRUCT)
+      (curry_mod_hash_with_hashes NFT_STATE_LAYER_MOD_HASH
+        (sha256 ONE NFT_STATE_LAYER_MOD_HASH)
+        (sha256 ONE bridge_height)
+        (sha256 ONE bridge_metadata_updater_hash)
+        bridge_inner_puzhash
+      )
+    )
+  )
+
+  ; utility function that turns the output of two calls to collapse_tree_and_note_leaf_info into a single return value
+  (defun branch_hash_and_merge_info ((TREE1 PAYMENTS1 TOTAL1 MIN1 MAX1) (TREE2 PAYMENTS2 TOTAL2 MIN2 MAX2))
+    (list
+      (sha256 TWO TREE1 TREE2)
+      (merge_list PAYMENTS1 PAYMENTS2)
+      (+ TOTAL1 TOTAL2)
+      (min MIN1 MIN2)
+      (max MAX1 MAX2)
+    )
+  )
+
+  (defun collapse_tree_and_note_leaf_info (TREE PAYMENTS TOTAL MIN_HEIGHT MAX_HEIGHT)
+    (if (l TREE)
+        (if (or (l (f TREE)) (l (r TREE)))  ; If either side is a cons, we have not reached a leaf pair yet
+            (branch_hash_and_merge_info
+              (collapse_tree_and_note_leaf_info (f TREE) () 0 MIN_HEIGHT MAX_HEIGHT)
+              ; we favor right because merge_list merges from left
+              (collapse_tree_and_note_leaf_info (r TREE) PAYMENTS TOTAL MIN_HEIGHT MAX_HEIGHT)
+            )
+            (branch_hash_and_merge_info
+              (list (sha256 ONE (f TREE)) () 0 MIN_HEIGHT MAX_HEIGHT)
+              (list (sha256 ONE (r TREE)) (c (r TREE) PAYMENTS) (+ TOTAL 1) (f TREE) (f TREE))
+            )
+        )
+        (list TREE PAYMENTS TOTAL MIN_HEIGHT MAX_HEIGHT)  ; All atoms that we reach must be pre-hashed subtrees
+    )
+  )
+
+  (defun assert_root_and_calculate_delegated_puzzle_hash
+    (
+      VALIDATION_ROOT
+      bridge_height
+      bridge_metadata_updater_hash
+      bridge_inner_puzhash
+      bridge_amount
+      (ROOT PAYMENTS TOTAL MIN_HEIGHT MAX_HEIGHT)
+    )
+
+    (assert
+      (= VALIDATION_ROOT ROOT)
+      ; Given the tree is honestly constructed, this ensures that a sequential set of integer heights was revealed
+      (= TOTAL (- MAX_HEIGHT MIN_HEIGHT))
+      ; You must reveal the current height of the bridge (no skipping heights)
+      (= bridge_height MIN_HEIGHT)
+      ; You cannot reveal heights less than the current height of the bridge (no double dipping)
+      (not (> bridge_height MAX_HEIGHT))
+      ; then
+      ; manual sha256tree expansion of:
+      ; (q .
+      ;   (
+      ;     (-24 bridge_metadata_updater_hash ((max_height bridge_metadata_updater_hash) ()))
+      ;     .
+      ;     (calculate_output_conditions_hash ...)
+      ;   )
+      ; )
+      (sha256 TWO
+        (sha256_one_one)
+        (sha256 TWO
+          (sha256 TWO
+            (sha256 ONE -24)
+            (sha256 TWO
+              bridge_metadata_updater_hash
+              (sha256 TWO
+                (sha256 TWO
+                  (sha256 TWO
+                    (sha256 ONE MAX_HEIGHT)
+                    (sha256 TWO
+                      (sha256 ONE bridge_metadata_updater_hash)
+                      (sha256_one)
+                    )
+                  )
+                  (sha256 TWO
+                    (sha256_one)  ; empty list of conditions
+                    (sha256_one)
+                  )
+                )
+                (sha256_one)
+              )
+            )
+          )
+          (calculate_output_conditions_hash
+            bridge_height
+            bridge_metadata_updater_hash
+            bridge_inner_puzhash
+            bridge_amount
+            PAYMENTS
+          )
+        )
+      )
+    )
+  )
+
+  (defun calculate_output_conditions_hash
+    (
+      bridge_height
+      bridge_metadata_updater_hash
+      bridge_inner_puzhash
+      bridge_amount
+      PAYMENTS
+    )
+
+    (if PAYMENTS
+      ; manual sha256tree expansion of ((CREATE_COIN (f PAYMENTS) 0) . (calculate_output_conditions_hash ...))
+      (sha256 TWO
+        (sha256 TWO
+          (sha256 ONE CREATE_COIN)
+          (sha256 TWO
+            (sha256 ONE (f PAYMENTS))
+            (sha256 TWO
+              (sha256_one)
+              (sha256_one)
+            )
+          )
+        )
+        (calculate_output_conditions_hash
+          bridge_height
+          bridge_metadata_updater_hash
+          bridge_inner_puzhash
+          bridge_amount
+          (r PAYMENTS)
+        )
+      )
+      ; else
+      ; manual sha256tree expansion of:
+      ; (
+      ;   (CREATE_PUZZLE_ANNOUNCEMENT bridge_height)
+      ;   (ASSERT_MY_AMOUNT bridge_amount)
+      ;   (CREATE_COIN bridge_inner_puzhash bridge_amount)
+      ; )
+      (sha256 TWO
+        (sha256 TWO
+          (sha256 ONE CREATE_PUZZLE_ANNOUNCEMENT)
+          (sha256 TWO
+            (sha256 ONE bridge_height)
+            (sha256_one)
+          )
+        )
+        (sha256 TWO
+          (sha256 TWO
+            (sha256 ONE ASSERT_MY_AMOUNT)
+            (sha256 TWO
+              (sha256 ONE bridge_amount)
+              (sha256_one)
+            )
+          )
+          (sha256 TWO
+            (sha256 TWO
+              (sha256 ONE CREATE_COIN)
+              (sha256 TWO
+                (sha256 ONE bridge_inner_puzhash)
+                (sha256 TWO
+                  (sha256 ONE bridge_amount)
+                  (sha256_one)
+                )
+              )
+            )
+            (sha256_one)
+          )
+        )
+      )
+    )
+  )
+
+  ; final conditions
+  (list
+    ; An announcement to the bridge of the delegated puzzle it should run
+    (list CREATE_PUZZLE_ANNOUNCEMENT
+      (sha256
+        (f (r BRIDGE_SINGLETON_STRUCT))
+        (assert_root_and_calculate_delegated_puzzle_hash
+          VALIDATION_ROOT
+          bridge_height
+          bridge_metadata_updater_hash
+          bridge_inner_puzhash
+          bridge_amount
+          (collapse_tree_and_note_leaf_info validations_proof () 0 bridge_height bridge_height)
+        )
+      )
+    )
+    ; Asserting an announcement from the delegated puzzle the bridge is running
+    (list ASSERT_PUZZLE_ANNOUNCEMENT
+      (sha256
+        (calculate_singleton_puzzle_hash
+          BRIDGE_SINGLETON_STRUCT
+          NFT_STATE_LAYER_MOD_HASH
+          bridge_height
+          bridge_metadata_updater_hash
+          bridge_inner_puzhash
+        )
+        bridge_height
+      )
+    )
+  )
+
+)

--- a/src/classic/bins/shrink.rs
+++ b/src/classic/bins/shrink.rs
@@ -36,7 +36,7 @@ fn main() {
                 program.args.clone(),
                 &HashMap::new(),
                 program.exp,
-                false,
+                Default::default(),
             )
         })
         .map(|result| {

--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -764,6 +764,7 @@ fn generate_let_defun(
             name: name.to_owned(),
             args: Rc::new(inner_function_args),
             body,
+            synthetic: true
         },
     )
 }
@@ -930,6 +931,7 @@ fn process_helper_let_bindings(
                         name: defun.name.clone(),
                         args: defun.args.clone(),
                         body: hoisted_body,
+                        synthetic: true
                     },
                 );
 

--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -429,6 +429,10 @@ fn compile_call(
                             l.clone(),
                             Rc::new(SExp::Integer(l.clone(), i.clone())),
                         )),
+                        BodyForm::Quoted(SExp::Integer(l, i)) => Ok(CompiledCode(
+                            l.clone(),
+                            Rc::new(SExp::Integer(l.clone(), i.clone())),
+                        )),
                         _ => Err(CompileErr(
                             al.clone(),
                             "@ form only accepts integers at present".to_string(),
@@ -447,6 +451,7 @@ fn compile_call(
                     let updated_opts = opts
                         .set_stdenv(false)
                         .set_in_defun(true)
+                        .set_frontend_opt(false)
                         .set_start_env(Some(compiler.env.clone()))
                         .set_compiler(compiler.clone());
 
@@ -635,6 +640,7 @@ fn codegen_(
                     .set_compiler(compiler.clone())
                     .set_in_defun(true)
                     .set_stdenv(false)
+                    .set_frontend_opt(false)
                     .set_start_env(Some(combine_defun_env(
                         compiler.env.clone(),
                         defun.args.clone(),

--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -777,7 +777,7 @@ fn generate_let_defun(
         count_occurrences(&b.name, body.borrow())
     }).sum();
 
-    let inline = !opts.frontend_opt() && deinline_score == 1;
+    let inline = !opts.frontend_opt() || deinline_score == 1;
     let h = HelperForm::Defun(
         inline,
         DefunData {

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -97,6 +97,12 @@ fn finish_optimization(sexp: &SExp) -> SExp {
                 return SExp::Nil(l.clone())
             }
         }
+
+        SExp::Cons(
+            l.clone(),
+            Rc::new(finish_optimization(a.borrow())),
+            Rc::new(finish_optimization(b.borrow()))
+        )
     }
 
     sexp.clone()

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -14,7 +14,7 @@ use crate::classic::clvm_tools::stages::stage_2::optimize::optimize_sexp;
 use crate::compiler::clvm::{convert_from_clvm_rs, convert_to_clvm_rs, sha256tree};
 use crate::compiler::codegen::codegen;
 use crate::compiler::comptypes::{
-    CompileErr, CompileForm, CompilerOpts, PrimaryCodegen,
+    CompileErr, CompilerOpts, PrimaryCodegen,
 };
 use crate::compiler::frontend::frontend;
 use crate::compiler::optimize::{fe_opt, finish_optimization, sexp_scale};
@@ -107,8 +107,6 @@ pub fn compile_pre_forms(
             finish_optimization(&codegen(allocator, runner, opts, &compileform_noninlined, symbol_table)?);
         let inlined_scale = sexp_scale(&generated_inlined);
         let noninlined_scale =  sexp_scale(&generated_noninlined);
-        eprintln!("generated_inlined {} {}", inlined_scale, generated_inlined);
-        eprintln!("generated_noninlined {} {}", noninlined_scale, generated_noninlined);
         let generated =
             if inlined_scale < noninlined_scale {
                 generated_inlined

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -98,11 +98,11 @@ fn finish_optimization(sexp: &SExp) -> SExp {
             }
         }
 
-        SExp::Cons(
+        return SExp::Cons(
             l.clone(),
             Rc::new(finish_optimization(a.borrow())),
             Rc::new(finish_optimization(b.borrow()))
-        )
+        );
     }
 
     sexp.clone()

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -100,18 +100,22 @@ pub fn compile_pre_forms(
         let compileform_inlined =
             fe_opt(allocator, runner.clone(), opts.clone(), &g, true)?;
         let generated_inlined =
-            codegen(allocator, runner.clone(), opts.clone(), &compileform_inlined, symbol_table)?;
+            finish_optimization(&codegen(allocator, runner.clone(), opts.clone(), &compileform_inlined, symbol_table)?);
         let compileform_noninlined =
             fe_opt(allocator, runner.clone(), opts.clone(), &g, false)?;
         let generated_noninlined =
-            codegen(allocator, runner, opts, &compileform_noninlined, symbol_table)?;
+            finish_optimization(&codegen(allocator, runner, opts, &compileform_noninlined, symbol_table)?);
+        let inlined_scale = sexp_scale(&generated_inlined);
+        let noninlined_scale =  sexp_scale(&generated_noninlined);
+        eprintln!("generated_inlined {} {}", inlined_scale, generated_inlined);
+        eprintln!("generated_noninlined {} {}", noninlined_scale, generated_noninlined);
         let generated =
-            if sexp_scale(&generated_inlined) < sexp_scale(&generated_noninlined) {
+            if inlined_scale < noninlined_scale {
                 generated_inlined
             } else {
                 generated_noninlined
             };
-        Ok(finish_optimization(&generated))
+        Ok(generated)
     } else {
         codegen(allocator, runner, opts.clone(), &g, symbol_table)
     }

--- a/src/compiler/comptypes.rs
+++ b/src/compiler/comptypes.rs
@@ -162,6 +162,7 @@ pub struct DefunCall {
 pub struct PrimaryCodegen {
     pub prims: Rc<HashMap<Vec<u8>, Rc<SExp>>>,
     pub constants: HashMap<Vec<u8>, Rc<SExp>>,
+    pub tabled_constants: HashMap<Vec<u8>, Rc<SExp>>,
     pub macros: HashMap<Vec<u8>, Rc<SExp>>,
     pub inlines: HashMap<Vec<u8>, InlineFunction>,
     pub defuns: HashMap<Vec<u8>, DefunCall>,
@@ -462,6 +463,12 @@ impl PrimaryCodegen {
     pub fn add_constant(&self, name: &[u8], value: Rc<SExp>) -> Self {
         let mut codegen_copy = self.clone();
         codegen_copy.constants.insert(name.to_owned(), value);
+        codegen_copy
+    }
+
+    pub fn add_tabled_constant(&self, name: &[u8], value: Rc<SExp>) -> Self {
+        let mut codegen_copy = self.clone();
+        codegen_copy.tabled_constants.insert(name.to_owned(), value);
         codegen_copy
     }
 

--- a/src/compiler/comptypes.rs
+++ b/src/compiler/comptypes.rs
@@ -96,6 +96,7 @@ pub struct DefunData {
     pub nl: Srcloc,
     pub args: Rc<SExp>,
     pub body: Rc<BodyForm>,
+    pub synthetic: bool
 }
 
 #[derive(Clone, Debug)]

--- a/src/compiler/comptypes.rs
+++ b/src/compiler/comptypes.rs
@@ -115,6 +115,7 @@ pub struct DefconstData {
     pub kw: Option<Srcloc>,
     pub nl: Srcloc,
     pub body: Rc<BodyForm>,
+    pub tabled: bool
 }
 
 #[derive(Clone, Debug)]

--- a/src/compiler/comptypes.rs
+++ b/src/compiler/comptypes.rs
@@ -96,7 +96,7 @@ pub struct DefunData {
     pub nl: Srcloc,
     pub args: Rc<SExp>,
     pub body: Rc<BodyForm>,
-    pub synthetic: bool
+    pub synthetic: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -116,7 +116,7 @@ pub struct DefconstData {
     pub kw: Option<Srcloc>,
     pub nl: Srcloc,
     pub body: Rc<BodyForm>,
-    pub tabled: bool
+    pub tabled: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/src/compiler/evaluate.rs
+++ b/src/compiler/evaluate.rs
@@ -798,7 +798,7 @@ impl Evaluator {
             let compiled_borrowed: &SExp = compiled.borrow();
             Ok(Rc::new(BodyForm::Quoted(compiled_borrowed.clone())))
         } else {
-            if arguments_to_convert.len() == 1 && !self.mash_conditions {
+            if arguments_to_convert.len() == 1 {
                 // Try to short circuit destruct conses.
                 let is_first = call_name == b"f" || call_name == vec![5];
                 if is_first || call_name == b"r" || call_name == vec![6] {

--- a/src/compiler/evaluate.rs
+++ b/src/compiler/evaluate.rs
@@ -445,7 +445,7 @@ fn promote_args_to_bodyform(
         for a in v.iter() {
             result.push(promote_program_to_bodyform(
                 Rc::new(a.clone()),
-                whole_args.clone(),
+                whole_args.clone()
             )?);
         }
         return Ok(result);
@@ -480,12 +480,6 @@ fn choose_from_env_by_path(path_: Number, args_program: Rc<BodyForm>) -> Rc<Body
 
     if path == bi_zero() {
         return Rc::new(BodyForm::Quoted(SExp::Nil(args_program.loc())));
-    }
-
-    if let Some((first, rest)) = recognize_consed_env(args_program.clone()) {
-        if (path.clone() & bi_one()) != bi_zero() {
-            return choose_from_env_by_path(path / 2_u32.to_bigint().unwrap(), rest);
-        }
     }
 
     while path != bi_one() {
@@ -680,7 +674,7 @@ impl Evaluator {
                 Rc::new(BodyForm::Value(SExp::Atom(
                     macro_expansion.loc(),
                     vec![b'@'],
-                ))),
+                )))
             )
         }
     }
@@ -804,7 +798,7 @@ impl Evaluator {
             let compiled_borrowed: &SExp = compiled.borrow();
             Ok(Rc::new(BodyForm::Quoted(compiled_borrowed.clone())))
         } else {
-            if arguments_to_convert.len() == 1 {
+            if arguments_to_convert.len() == 1 && !self.mash_conditions {
                 // Try to short circuit destruct conses.
                 let is_first = call_name == b"f" || call_name == vec![5];
                 if is_first || call_name == b"r" || call_name == vec![6] {

--- a/src/compiler/evaluate.rs
+++ b/src/compiler/evaluate.rs
@@ -304,8 +304,7 @@ fn show_env(env: &HashMap<Vec<u8>, Rc<BodyForm>>) {
     let loc = Srcloc::start("*env*");
     for kv in env.iter() {
         eprintln!(
-            "{} - {}: {}",
-            show_indent(),
+            "- {}: {}",
             SExp::Atom(loc.clone(), kv.0.clone()),
             kv.1.to_sexp()
         );
@@ -757,9 +756,15 @@ impl Evaluator {
                         recognize_consed_env(arguments_to_convert[0].clone())
                     {
                         if is_first {
-                            return Ok(first);
+                            let evaluated_first = self.shrink_bodyform_visited(
+                                allocator, visited, prog_args, env, first, expand,
+                            )?;
+                            return Ok(evaluated_first);
                         } else {
-                            return Ok(rest);
+                            let evaluated_rest = self.shrink_bodyform_visited(
+                                allocator, visited, prog_args, env, rest, expand,
+                            )?;
+                            return Ok(evaluated_rest);
                         }
                     }
                 }
@@ -991,7 +996,6 @@ impl Evaluator {
                         kv.1.clone(),
                         expand.clone(),
                     )?;
-
                     argument_captures.insert(kv.0.clone(), shrunk.clone());
                 }
 

--- a/src/compiler/evaluate.rs
+++ b/src/compiler/evaluate.rs
@@ -1194,7 +1194,7 @@ impl Evaluator {
                             }
                         })
                         .unwrap_or_else(|| {
-                            self.get_constant(name)
+                            self.get_constant(name, only_inline)
                                 .map(|x| {
                                     self.shrink_bodyform_visited(
                                         allocator,
@@ -1421,10 +1421,10 @@ impl Evaluator {
         self.helpers.push(h.clone());
     }
 
-    fn get_constant(&self, name: &[u8]) -> Option<Rc<BodyForm>> {
+    fn get_constant(&self, name: &[u8], only_inline: bool) -> Option<Rc<BodyForm>> {
         for h in self.helpers.iter() {
             if let HelperForm::Defconstant(defc) = h {
-                if defc.name == name {
+                if defc.name == name && (!defc.tabled || !only_inline) {
                     return Some(defc.body.clone());
                 }
             }

--- a/src/compiler/evaluate.rs
+++ b/src/compiler/evaluate.rs
@@ -308,7 +308,7 @@ pub fn dequote(l: Srcloc, exp: Rc<BodyForm>) -> Result<Rc<SExp>, CompileErr> {
 fn show_env(env: &HashMap<Vec<u8>, Rc<BodyForm>>) {
     let loc = Srcloc::start(&"*env*".to_string());
     for kv in env.iter() {
-        println!(
+        eprintln!(
             "{} - {}: {}",
             show_indent(),
             SExp::Atom(loc.clone(), kv.0.clone()).to_string(),
@@ -458,7 +458,7 @@ fn promote_args_to_bodyform(
 }
 
 fn recognize_consed_env(args_program: Rc<BodyForm>) -> Option<(Rc<BodyForm>, Rc<BodyForm>)> {
-    if let BodyForm::Call(l, args) = args_program.borrow() {
+    if let BodyForm::Call(_l, args) = args_program.borrow() {
         if args.len() != 3 {
             return None;
         }
@@ -998,7 +998,7 @@ impl Evaluator {
         l: Srcloc,
         call_loc: Srcloc,
         call_name: &[u8],
-        head_expr: Rc<BodyForm>,
+        _head_expr: Rc<BodyForm>,
         parts: &[Rc<BodyForm>],
         body: Rc<BodyForm>,
         prog_args: Rc<SExp>,

--- a/src/compiler/frontend.rs
+++ b/src/compiler/frontend.rs
@@ -8,7 +8,6 @@ use crate::compiler::comptypes::{
     list_to_cons, Binding, BodyForm, CompileErr, CompileForm, CompilerOpts, DefconstData,
     DefmacData, DefunData, HelperForm, IncludeDesc, LetData, LetFormKind, ModAccum,
 };
-use crate::compiler::optimize::sexp_scale;
 use crate::compiler::preprocessor::preprocess;
 use crate::compiler::rename::rename_children_compileform;
 use crate::compiler::sexp::{enlist, SExp};
@@ -383,8 +382,6 @@ fn compile_defconstant(
         }))
     } else {
         compile_bodyform(opts.clone(), body.clone()).map(|bf| {
-            let bf_sexp = bf.to_sexp();
-            let bf_generated: &SExp = bf_sexp.borrow();
             HelperForm::Defconstant(DefconstData {
                 loc: l,
                 nl,

--- a/src/compiler/frontend.rs
+++ b/src/compiler/frontend.rs
@@ -378,17 +378,17 @@ fn compile_defconstant(
             kw: kwl,
             name: name.to_vec(),
             body: Rc::new(BodyForm::Value(body_borrowed.clone())),
-            tabled: false
+            tabled: opts.frontend_opt()
         }))
     } else {
-        compile_bodyform(opts, body).map(|bf| {
+        compile_bodyform(opts.clone(), body.clone()).map(|bf| {
             HelperForm::Defconstant(DefconstData {
                 loc: l,
                 nl,
                 kw: kwl,
                 name: name.to_vec(),
                 body: Rc::new(bf),
-                tabled: false
+                tabled: opts.frontend_opt() && body.to_string().len() > 3
             })
         })
     }

--- a/src/compiler/frontend.rs
+++ b/src/compiler/frontend.rs
@@ -378,6 +378,7 @@ fn compile_defconstant(
             kw: kwl,
             name: name.to_vec(),
             body: Rc::new(BodyForm::Value(body_borrowed.clone())),
+            tabled: false
         }))
     } else {
         compile_bodyform(opts, body).map(|bf| {
@@ -387,6 +388,7 @@ fn compile_defconstant(
                 kw: kwl,
                 name: name.to_vec(),
                 body: Rc::new(bf),
+                tabled: false
             })
         })
     }

--- a/src/compiler/frontend.rs
+++ b/src/compiler/frontend.rs
@@ -378,7 +378,7 @@ fn compile_defconstant(
             kw: kwl,
             name: name.to_vec(),
             body: Rc::new(BodyForm::Value(body_borrowed.clone())),
-            tabled: opts.frontend_opt()
+            tabled: opts.frontend_opt(),
         }))
     } else {
         compile_bodyform(opts.clone(), body.clone()).map(|bf| {
@@ -388,7 +388,7 @@ fn compile_defconstant(
                 kw: kwl,
                 name: name.to_vec(),
                 body: Rc::new(bf),
-                tabled: opts.frontend_opt()
+                tabled: opts.frontend_opt(),
             })
         })
     }
@@ -430,7 +430,7 @@ fn compile_defun(opts: Rc<dyn CompilerOpts>, data: CompileDefun) -> Result<Helpe
                 name: data.name,
                 args: data.args,
                 body: Rc::new(bf),
-                synthetic: false
+                synthetic: false,
             },
         )
     })

--- a/src/compiler/frontend.rs
+++ b/src/compiler/frontend.rs
@@ -391,7 +391,7 @@ fn compile_defconstant(
                 kw: kwl,
                 name: name.to_vec(),
                 body: Rc::new(bf),
-                tabled: opts.frontend_opt() && sexp_scale(bf_generated) > 3
+                tabled: opts.frontend_opt()
             })
         })
     }

--- a/src/compiler/optimize.rs
+++ b/src/compiler/optimize.rs
@@ -1,10 +1,12 @@
+use num_bigint::ToBigInt;
+
 use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use clvm_rs::allocator::Allocator;
 
-use crate::classic::clvm::__type_compatibility__::bi_zero;
+use crate::classic::clvm::__type_compatibility__::{bi_one, bi_zero};
 use crate::classic::clvm_tools::stages::stage_0::TRunProgram;
 
 use crate::compiler::clvm::run;
@@ -52,6 +54,13 @@ pub fn sexp_scale(sexp: &SExp) -> u64 {
             1_u64 + bytes
         }
     }
+}
+
+#[test]
+fn test_sexp_scale_increases_with_atom_size() {
+    let l = Srcloc::start("*test*");
+    assert!(sexp_scale(&SExp::Integer(l.clone(), bi_one())) <
+            sexp_scale(&SExp::Integer(l, 1000000_u32.to_bigint().unwrap())));
 }
 
 pub fn optimize_expr(

--- a/src/compiler/optimize.rs
+++ b/src/compiler/optimize.rs
@@ -324,7 +324,7 @@ pub fn fe_opt(
 
     let mut optimized_helpers: Vec<HelperForm> = Vec::new();
     for h in compiler_helpers.iter() {
-        if let HelperForm::Defun(inline, defun) = &h {
+        if let HelperForm::Defun(false, defun) = &h {
             let ref_compileform = CompileForm {
                 loc: compileform.loc.clone(),
                 include_forms: compileform.include_forms.clone(),
@@ -344,7 +344,7 @@ pub fn fe_opt(
 
             let mut new_defun = defun.clone();
             new_defun.body = better_form.exp.clone();
-            optimized_helpers.push(HelperForm::Defun(*inline, new_defun));
+            optimized_helpers.push(HelperForm::Defun(false, new_defun));
         } else {
             optimized_helpers.push(h.clone());
         }

--- a/src/compiler/rename.rs
+++ b/src/compiler/rename.rs
@@ -285,6 +285,7 @@ fn rename_in_helperform(namemap: &HashMap<Vec<u8>, Vec<u8>>, h: &HelperForm) -> 
                 name: defun.name.to_vec(),
                 args: defun.args.clone(),
                 body: Rc::new(rename_in_bodyform(namemap, defun.body.clone())),
+                synthetic: defun.synthetic
             },
         ),
     }
@@ -343,6 +344,7 @@ fn rename_args_helperform(h: &HelperForm) -> HelperForm {
                         &local_namemap,
                         Rc::new(local_renamed_body),
                     )),
+                    synthetic: defun.synthetic
                 },
             )
         }

--- a/src/compiler/rename.rs
+++ b/src/compiler/rename.rs
@@ -266,6 +266,7 @@ fn rename_in_helperform(namemap: &HashMap<Vec<u8>, Vec<u8>>, h: &HelperForm) -> 
             nl: defc.nl.clone(),
             kw: defc.kw.clone(),
             body: Rc::new(rename_in_bodyform(namemap, defc.body.clone())),
+            tabled: defc.tabled
         }),
         HelperForm::Defmacro(mac) => HelperForm::Defmacro(DefmacData {
             loc: mac.loc.clone(),
@@ -273,7 +274,7 @@ fn rename_in_helperform(namemap: &HashMap<Vec<u8>, Vec<u8>>, h: &HelperForm) -> 
             nl: mac.nl.clone(),
             name: mac.name.to_vec(),
             args: mac.args.clone(),
-            program: Rc::new(rename_in_compileform(namemap, mac.program.clone())),
+            program: Rc::new(rename_in_compileform(namemap, mac.program.clone()))
         }),
         HelperForm::Defun(inline, defun) => HelperForm::Defun(
             *inline,
@@ -297,6 +298,7 @@ fn rename_args_helperform(h: &HelperForm) -> HelperForm {
             kw: defc.kw.clone(),
             name: defc.name.clone(),
             body: Rc::new(rename_args_bodyform(defc.body.borrow())),
+            tabled: defc.tabled
         }),
         HelperForm::Defmacro(mac) => {
             let mut new_names: HashMap<Vec<u8>, Vec<u8>> = HashMap::new();

--- a/src/compiler/rename.rs
+++ b/src/compiler/rename.rs
@@ -266,7 +266,7 @@ fn rename_in_helperform(namemap: &HashMap<Vec<u8>, Vec<u8>>, h: &HelperForm) -> 
             nl: defc.nl.clone(),
             kw: defc.kw.clone(),
             body: Rc::new(rename_in_bodyform(namemap, defc.body.clone())),
-            tabled: defc.tabled
+            tabled: defc.tabled,
         }),
         HelperForm::Defmacro(mac) => HelperForm::Defmacro(DefmacData {
             loc: mac.loc.clone(),
@@ -274,7 +274,7 @@ fn rename_in_helperform(namemap: &HashMap<Vec<u8>, Vec<u8>>, h: &HelperForm) -> 
             nl: mac.nl.clone(),
             name: mac.name.to_vec(),
             args: mac.args.clone(),
-            program: Rc::new(rename_in_compileform(namemap, mac.program.clone()))
+            program: Rc::new(rename_in_compileform(namemap, mac.program.clone())),
         }),
         HelperForm::Defun(inline, defun) => HelperForm::Defun(
             *inline,
@@ -285,7 +285,7 @@ fn rename_in_helperform(namemap: &HashMap<Vec<u8>, Vec<u8>>, h: &HelperForm) -> 
                 name: defun.name.to_vec(),
                 args: defun.args.clone(),
                 body: Rc::new(rename_in_bodyform(namemap, defun.body.clone())),
-                synthetic: defun.synthetic
+                synthetic: defun.synthetic,
             },
         ),
     }
@@ -299,7 +299,7 @@ fn rename_args_helperform(h: &HelperForm) -> HelperForm {
             kw: defc.kw.clone(),
             name: defc.name.clone(),
             body: Rc::new(rename_args_bodyform(defc.body.borrow())),
-            tabled: defc.tabled
+            tabled: defc.tabled,
         }),
         HelperForm::Defmacro(mac) => {
             let mut new_names: HashMap<Vec<u8>, Vec<u8>> = HashMap::new();
@@ -344,7 +344,7 @@ fn rename_args_helperform(h: &HelperForm) -> HelperForm {
                         &local_namemap,
                         Rc::new(local_renamed_body),
                     )),
-                    synthetic: defun.synthetic
+                    synthetic: defun.synthetic,
                 },
             )
         }

--- a/src/compiler/repl.rs
+++ b/src/compiler/repl.rs
@@ -172,7 +172,7 @@ impl Repl {
                                 program.args.clone(),
                                 &HashMap::new(),
                                 program.exp,
-                                false,
+                                Default::default(),
                             )
                         })
                         .map(Some)

--- a/src/compiler/sexp.rs
+++ b/src/compiler/sexp.rs
@@ -462,6 +462,14 @@ impl SExp {
         }
     }
 
+    pub fn atomize(&self) -> SExp {
+        if let SExp::Integer(l, i) = self {
+            SExp::Atom(l.clone(), u8_from_number(i.clone()))
+        } else {
+            self.clone()
+        }
+    }
+
     pub fn equal_to(&self, other: &SExp) -> bool {
         if self.nilp() && other.nilp() {
             true

--- a/src/compiler/usecheck.rs
+++ b/src/compiler/usecheck.rs
@@ -91,7 +91,7 @@ pub fn check_parameters_used_compileform(
         program.args.clone(),
         &env,
         program.exp.clone(),
-        false,
+        Default::default(),
     )?;
 
     remove_present_atoms(&mut replacement_to_original, result.to_sexp());

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -521,7 +521,7 @@ fn test_classic_sets_source_file_in_symbols() {
 
 #[test]
 fn test_classic_sets_source_file_in_symbols_only_when_asked() {
-    let tname = "test_classic_sets_source_file_in_symbols.sym".to_string();
+    let tname = "test_classic_sets_source_file_in_symbols_when_asked.sym".to_string();
     do_basic_run(&vec![
         "run".to_string(),
         "--symbol-output-file".to_string(),

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -1168,7 +1168,7 @@ fn test_cl22_opt_example_1() {
      )
     )"}.to_string();
     let res = run_string(&prog, &"(3)".to_string()).unwrap();
-    assert_eq!(res.to_string(), "0x5b8d92"); // 6000018
+    assert_eq!(res.to_string(), "6000018");
 }
 
 #[test]

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -11,7 +11,7 @@ use crate::compiler::runtypes::RunFailure;
 use crate::compiler::sexp::{parse_sexp, SExp};
 use crate::compiler::srcloc::Srcloc;
 
-fn compile_string(content: &String) -> Result<String, CompileErr> {
+pub fn compile_string(content: &String) -> Result<String, CompileErr> {
     let mut allocator = Allocator::new();
     let runner = Rc::new(DefaultProgramRunner::new());
     let opts = Rc::new(DefaultCompilerOpts::new(&"*test*".to_string()));

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -1166,7 +1166,8 @@ fn test_cl22_opt_example_1() {
       ((X1 (+ X Z)))
       (+ X1 X1 X1 X1 X1 X1)
      )
-    )"}.to_string();
+    )"}
+    .to_string();
     let res = run_string(&prog, &"(3)".to_string()).unwrap();
     assert_eq!(res.to_string(), "6000018");
 }

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -1157,6 +1157,21 @@ fn test_defconstant_tree() {
 }
 
 #[test]
+fn test_cl22_opt_example_1() {
+    let prog = indoc! {"
+    (mod (X)
+     (include *standard-cl-22*)
+     (defconstant Z 1000000)
+     (let
+      ((X1 (+ X Z)))
+      (+ X1 X1 X1 X1 X1 X1)
+     )
+    )"}.to_string();
+    let res = run_string(&prog, &"(3)".to_string()).unwrap();
+    assert_eq!(res.to_string(), "0x5b8d92"); // 6000018
+}
+
+#[test]
 fn test_inline_out_of_bounds_diagnostic() {
     let prog = indoc! {"
 (mod ()

--- a/src/tests/compiler/compiler.rs
+++ b/src/tests/compiler/compiler.rs
@@ -42,6 +42,7 @@ fn run_string_maybe_opt(
         &mut HashMap::new(),
     )
     .and_then(|x| {
+        eprintln!("run {}", x);
         run(
             &mut allocator,
             runner,
@@ -57,7 +58,15 @@ fn run_string_maybe_opt(
 }
 
 fn run_string(content: &String, args: &String) -> Result<Rc<SExp>, CompileErr> {
-    run_string_maybe_opt(content, args, false)
+    let unopt = run_string_maybe_opt(content, args, false)?;
+    eprintln!("result-uno {}", unopt);
+
+    eprintln!("*** OPTIMIZED ***");
+    let opt = run_string_maybe_opt(content, args, true)?;
+    eprintln!("result-opt {}", opt);
+
+    assert_eq!(unopt, opt);
+    Ok(opt)
 }
 
 /* // Upcoming support for extra optimization (WIP)

--- a/src/tests/compiler/evaluate.rs
+++ b/src/tests/compiler/evaluate.rs
@@ -117,6 +117,6 @@ fn compile_with_fe_opt(s: String) -> Result<String, CompileErr> {
 fn test_simple_fe_opt_compile_1() {
     assert_eq!(
         compile_with_fe_opt("(mod () 99)".to_string()).unwrap(),
-        "(2 (1 1 . 99) (4 (1) 1))".to_string()
+        "(2 (1 1 . 99) (4 () 1))".to_string()
     );
 }

--- a/src/tests/compiler/evaluate.rs
+++ b/src/tests/compiler/evaluate.rs
@@ -32,7 +32,7 @@ fn shrink_expr_from_string(s: String) -> Result<String, CompileErr> {
                 program.args.clone(),
                 &HashMap::new(),
                 program.exp.clone(),
-                false,
+                Default::default(),
             );
         })
         .map(|result| result.to_sexp().to_string())

--- a/src/tests/compiler/mod.rs
+++ b/src/tests/compiler/mod.rs
@@ -7,6 +7,7 @@ use crate::compiler::srcloc::{Srcloc, Until};
 mod clvm;
 mod compiler;
 mod evaluate;
+mod optimizer;
 mod repl;
 mod srcloc;
 mod usecheck;

--- a/src/tests/compiler/optimizer.rs
+++ b/src/tests/compiler/optimizer.rs
@@ -14,7 +14,7 @@ use crate::compiler::sexp::{parse_sexp, SExp};
 use crate::compiler::srcloc::Srcloc;
 
 struct CompileRunResult {
-    pub compiled: Rc<SExp>,
+    // pub compiled: Rc<SExp>,
     pub compiled_hex: String,
     pub run_result: Rc<SExp>,
     pub run_cost: u64
@@ -43,7 +43,7 @@ fn run_with_cost(
         RunFailure::RunErr(sexp.loc(), format!("{} in {} {}", e.1, sexp, env))
     }).and_then(|reduction| {
         Ok(CompileRunResult {
-            compiled: sexp.clone(),
+            // compiled: sexp.clone(),
             compiled_hex,
             run_result: convert_from_clvm_rs(allocator, sexp.loc(), reduction.1)?,
             run_cost: reduction.0
@@ -72,8 +72,6 @@ fn run_string_get_program_and_output_with_includes(
         &mut HashMap::new(),
     )
         .and_then(|program| {
-            eprintln!("program {}", program);
-            eprintln!("sexp_args {}", sexp_args);
             run_with_cost(
                 &mut allocator,
                 runner,

--- a/src/tests/compiler/optimizer.rs
+++ b/src/tests/compiler/optimizer.rs
@@ -114,3 +114,22 @@ fn smoke_test_optimizer() {
     assert!(res.opt.compiled_hex.len() < res.unopt.compiled_hex.len());
     assert!(res.opt.run_cost < res.unopt.run_cost);
 }
+
+#[test]
+fn test_optimizer_shrinks_inlines() {
+    let res = do_compile_and_run_opt_size_test(
+        indoc!{"
+        (mod (A)
+          (include *standard-cl-22*)
+          (defun-inline F (N) (* 3 (+ 1 N)))
+          (let* ((FN (F A)))
+            (let ((FA (+ FN 1)) (FB (- FN 1)) (FC (* FN 2)))
+              (+ FA FB FC)
+              )
+            )
+          )
+        "},
+        "(3)"
+    ).expect("should compile and run");
+    assert!(res.opt.compiled_hex.len() < res.unopt.compiled_hex.len());
+}

--- a/src/tests/compiler/optimizer.rs
+++ b/src/tests/compiler/optimizer.rs
@@ -13,7 +13,7 @@ use crate::compiler::sexp::{parse_sexp, SExp};
 use crate::compiler::srcloc::Srcloc;
 
 struct CompileRunResult {
-    pub compiled: Rc<SExp>,
+    // pub compiled: Rc<SExp>,
     pub compiled_hex: String,
     pub run_result: Rc<SExp>,
     pub run_cost: u64
@@ -42,7 +42,7 @@ fn run_with_cost(
         RunFailure::RunErr(sexp.loc(), format!("{} in {} {}", e.1, sexp, env))
     }).and_then(|reduction| {
         Ok(CompileRunResult {
-            compiled: sexp.clone(),
+            // compiled: sexp.clone(),
             compiled_hex,
             run_result: convert_from_clvm_rs(allocator, sexp.loc(), reduction.1)?,
             run_cost: reduction.0
@@ -113,5 +113,4 @@ fn smoke_test_optimizer() {
     ).expect("should compile and run");
     assert!(res.opt.compiled_hex.len() < res.unopt.compiled_hex.len());
     assert!(res.opt.run_cost < res.unopt.run_cost);
-    assert_eq!(res.opt.compiled.to_string(), "(2 (1 1 . 6) (4 (1) 1))");
 }

--- a/src/tests/compiler/optimizer.rs
+++ b/src/tests/compiler/optimizer.rs
@@ -148,5 +148,7 @@ fn test_optimizer_shrinks_repeated_lets() {
     )"},
         "(3)"
     ).expect("should compile and run");
+    eprintln!("res.unopt.compiled_hex {}", res.unopt.compiled_hex);
+    eprintln!("res.opt.compiled_hex . {}", res.opt.compiled_hex);
     assert!(res.opt.compiled_hex.len() < res.unopt.compiled_hex.len());
 }

--- a/src/tests/compiler/optimizer.rs
+++ b/src/tests/compiler/optimizer.rs
@@ -100,6 +100,21 @@ fn do_compile_and_run_opt_size_test(
 }
 
 #[test]
+fn test_optimizer_tables_big_constants() {
+    let res = do_compile_and_run_opt_size_test(
+        indoc!{"
+        (mod (A)
+         (include *standard-cl-22*)
+         (defconstant X \"hi there this is a test\")
+         (c X (c X A))
+         )
+        "},
+        "(test)"
+    ).expect("should compile and run");
+    assert!(res.opt.compiled_hex.len() < res.unopt.compiled_hex.len());
+}
+
+#[test]
 fn smoke_test_optimizer() {
     let res = do_compile_and_run_opt_size_test(
         indoc!{"
@@ -148,7 +163,5 @@ fn test_optimizer_shrinks_repeated_lets() {
     )"},
         "(3)"
     ).expect("should compile and run");
-    eprintln!("res.unopt.compiled_hex {}", res.unopt.compiled_hex);
-    eprintln!("res.opt.compiled_hex . {}", res.opt.compiled_hex);
     assert!(res.opt.compiled_hex.len() < res.unopt.compiled_hex.len());
 }

--- a/src/tests/compiler/optimizer.rs
+++ b/src/tests/compiler/optimizer.rs
@@ -1,0 +1,120 @@
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use clvm_rs::allocator::Allocator;
+
+use crate::classic::clvm::sexp::sexp_as_bin;
+use crate::classic::clvm_tools::stages::stage_0::{DefaultProgramRunner, TRunProgram};
+use crate::compiler::clvm::{convert_from_clvm_rs, convert_to_clvm_rs};
+use crate::compiler::compiler::{compile_file, DefaultCompilerOpts};
+use crate::compiler::comptypes::{CompileErr, CompilerOpts};
+use crate::compiler::runtypes::RunFailure;
+use crate::compiler::sexp::{parse_sexp, SExp};
+use crate::compiler::srcloc::Srcloc;
+
+struct CompileRunResult {
+    pub compiled: Rc<SExp>,
+    pub compiled_hex: String,
+    pub run_result: Rc<SExp>,
+    pub run_cost: u64
+}
+
+struct OptRunResult {
+    unopt: CompileRunResult,
+    opt: CompileRunResult
+}
+
+fn run_with_cost(
+    allocator: &mut Allocator,
+    runner: Rc<dyn TRunProgram>,
+    sexp: Rc<SExp>,
+    env: Rc<SExp>
+) -> Result<CompileRunResult, RunFailure> {
+    let as_classic_program = convert_to_clvm_rs(allocator, sexp.clone())?;
+    let as_classic_env = convert_to_clvm_rs(allocator, env.clone())?;
+    let compiled_hex = sexp_as_bin(allocator, as_classic_program).hex();
+    runner.run_program(
+        allocator,
+        as_classic_program,
+        as_classic_env,
+        None
+    ).map_err(|e| {
+        RunFailure::RunErr(sexp.loc(), format!("{} in {} {}", e.1, sexp, env))
+    }).and_then(|reduction| {
+        Ok(CompileRunResult {
+            compiled: sexp.clone(),
+            compiled_hex,
+            run_result: convert_from_clvm_rs(allocator, sexp.loc(), reduction.1)?,
+            run_cost: reduction.0
+        })
+    })
+}
+
+fn run_string_get_program_and_output(
+    content: &str, args: &str, fe_opt: bool
+) -> Result<CompileRunResult, CompileErr> {
+    let mut allocator = Allocator::new();
+    let runner = Rc::new(DefaultProgramRunner::new());
+    let mut opts: Rc<dyn CompilerOpts> = Rc::new(DefaultCompilerOpts::new(&"*test*".to_string()));
+    let srcloc = Srcloc::start(&"*test*".to_string());
+    opts = opts
+        .set_frontend_opt(fe_opt)
+        .set_search_paths(&vec!["resources/tests".to_string()]);
+    let sexp_args =
+        parse_sexp(srcloc.clone(), args.bytes()).map_err(|e| CompileErr(e.0, e.1))?[0].clone();
+
+    compile_file(
+        &mut allocator,
+        runner.clone(),
+        opts,
+        &content,
+        &mut HashMap::new(),
+    )
+        .and_then(|program| {
+            run_with_cost(
+                &mut allocator,
+                runner,
+                Rc::new(program),
+                sexp_args
+            )
+                .map_err(|e| match e {
+                    RunFailure::RunErr(l, s) => CompileErr(l, s),
+                    RunFailure::RunExn(l, s) => CompileErr(l, s.to_string()),
+                })
+        })
+}
+
+fn do_compile_and_run_opt_size_test(
+    prog: &str, env: &str
+) -> Result<OptRunResult, CompileErr> {
+    let unopt_run = run_string_get_program_and_output(prog, env, false)?;
+    let opt_run = run_string_get_program_and_output(prog, env, true)?;
+
+    // Ensure the runs had the same output.
+    assert_eq!(unopt_run.run_result, opt_run.run_result);
+
+    Ok(OptRunResult {
+        unopt: unopt_run,
+        opt: opt_run
+    })
+}
+
+#[test]
+fn smoke_test_optimizer() {
+    let res = do_compile_and_run_opt_size_test(
+        indoc!{"
+        (mod ()
+         (include *standard-cl-22*)
+         (defun-inline F (X Y) (+ X Y))
+         (let ((A 2) (B 4)) (F A B))
+          )
+        "},
+        "()"
+    ).expect("should compile and run");
+    assert!(
+        res.opt.compiled_hex.len() <
+        res.unopt.compiled_hex.len()
+    );
+    assert!(res.opt.run_cost < res.unopt.run_cost);
+    assert_eq!(res.opt.compiled.to_string(), "(2 (1 1 . 6) (4 (1) 1))");
+}

--- a/src/tests/compiler/optimizer.rs
+++ b/src/tests/compiler/optimizer.rs
@@ -111,10 +111,7 @@ fn smoke_test_optimizer() {
         "},
         "()"
     ).expect("should compile and run");
-    assert!(
-        res.opt.compiled_hex.len() <
-        res.unopt.compiled_hex.len()
-    );
+    assert!(res.opt.compiled_hex.len() < res.unopt.compiled_hex.len());
     assert!(res.opt.run_cost < res.unopt.run_cost);
     assert_eq!(res.opt.compiled.to_string(), "(2 (1 1 . 6) (4 (1) 1))");
 }

--- a/src/tests/compiler/repl.rs
+++ b/src/tests/compiler/repl.rs
@@ -147,8 +147,8 @@ fn test_repl_supports_at_capture() {
             "(defun F (A (@ Z (B C)) D) (c (+ A B C D) Z))",
             "(F 1 (q 2 3) 4)",
         ])
-            .unwrap()
-            .unwrap(),
+        .unwrap()
+        .unwrap(),
         "(q 10 2 3)"
     );
 }

--- a/src/tests/compiler/repl.rs
+++ b/src/tests/compiler/repl.rs
@@ -147,8 +147,8 @@ fn test_repl_supports_at_capture() {
             "(defun F (A (@ Z (B C)) D) (c (+ A B C D) Z))",
             "(F 1 (q 2 3) 4)",
         ])
-        .unwrap()
-        .unwrap(),
+            .unwrap()
+            .unwrap(),
         "(q 10 2 3)"
     );
 }
@@ -184,5 +184,20 @@ fn test_mod_in_repl() {
             .unwrap()
             .unwrap(),
         "(q . 10)"
+    );
+}
+
+#[test]
+fn test_optimize_let_binding_1_4() {
+    assert_eq!(
+        test_repl_outcome(vec![
+            "(defconstant a 100)",
+            "(defun letbinding_$_265 args args)",
+            "(defun-inline letbinding_$_264 ((a) x) (letbinding_$_265 (c (c a ()) (c x ())) (+ x 1)))",
+            "(letbinding_$_264 (list a) (+ a 1))"
+        ])
+            .unwrap()
+            .unwrap(),
+        "(q ((100) 101) 102)"
     );
 }

--- a/src/tests/compiler/repl.rs
+++ b/src/tests/compiler/repl.rs
@@ -201,3 +201,18 @@ fn test_optimize_let_binding_1_4() {
         "(q ((100) 101) 102)"
     );
 }
+
+#[test]
+fn test_intermediate_let_final() {
+    assert_eq!(
+        test_repl_outcome(vec![
+            "(defun-inline letbinding_$_265 (((a) x_$_263) y) (+ x_$_263 y))",
+            "(defun-inline letbinding_$_264 ((a) x) (letbinding_$_265 (c (c a ()) (c x ())) (+ x 1)))",
+            "(defun main (a) (letbinding_$_264 (r @) (+ a 1)))",
+            "(main 100)"
+        ])
+            .unwrap()
+            .unwrap(),
+        "(q . 203)"
+    );
+}


### PR DESCRIPTION
This completes the frontend optimizer and allows ```*standard-cl-22*``` to enable it.
The optimizer has a few improvements when enabled:
1) Constants can be designated as being 'tabled', which means they enter the left environment.
2) The repl's evaluator is tried and its output taken instead of the basic inliner in cl21 if it saves space.
3) Defuns created by let forms are marked 'synthetic' and the compiler tries producing them without inlining, taking the choices that save space.
4) The repl's evaluator now emulates both halves of the environment.
5) The repl's evaluator now combines (f (c x _)) to x and (r (c _ x)) to x as a short circuit optimization.
6) A few other fixes for things exposed by enabling this machinery.